### PR TITLE
updated model metadata schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ We ask modeling teams to submit predictions of frequencies of the predominant SA
 
 ### Submitting to the hub
 
-**How to submit**: Any team wishing to submit a set of nowcasts to the hub may submit a pull-request to this repository with a valid submission file in parquet format. The submission file must be located in `model-output/<team>-<model>/` (where `<team>` and `<model>` are the abbreviated names of your team and your model, respectively), and the submission file must be named `YYYY-MM-DD-<team>-<model>.parquet` where `YYYY-MM-DD` is the date of the Wednesday on which the submission is due. Teams must also submit a model metadata file (see details [below](#model-metadata)). 
+**How to submit**: Any team wishing to submit a set of nowcasts to the hub may submit a pull-request to this repository with a valid submission file in parquet format. The submission file must be located in `model-output/<team>-<model>/` (where `<team>` and `<model>` are the abbreviated names of your team and your model, respectively), and the submission file must be named `YYYY-MM-DD-<team>-<model>.parquet` where `YYYY-MM-DD` is the date of the Wednesday on which the submission is due. Teams must also submit a model metadata file (see details [on the Model Metadata README page](https://github.com/reichlab/variant-nowcast-hub/blob/main/model-metadata/README.md)). 
 
 **Deadline**: Submissions are due at 8pm ET every Wednesday. This time was chosen to give modelers time in the beginning of the week to run and adjust models and stakeholders time at the end of the week to incorporate preliminary results into discussions or decision making.
 
@@ -41,8 +41,6 @@ We note that sample IDs present in the `output_type_id` column of submissions ar
 
 To be included in the hub ensemble model, samples must be submitted and the mean forecast for the hub ensemble will be obtained as a summary of sample predictions.
 
-## <a name="model-metadata"></a>Model metadata
-TODO
 
 ## Data created and stored by the hub
 
@@ -52,7 +50,7 @@ Early Monday morning (~3am ET) prior to a Wednesday on which submissions are due
 1. `clades`: an array of [NextClade clade names](https://clades.nextstrain.org/about) that will be accepted in submission files for the upcoming deadline.
 2. `meta`: metadata relevant to the upcoming round, including links to the Nextstrain sequence information and reference tree used to generate the above `clades` array.
 
-The JSON file will live in the `auxiliary-data/modeled-clades/` directory of the repository and will be named “YYYY-MM-DD.json” where “YYYY-MM-DD” is the date of the Wednesday on which submissions are due
+The JSON file will live in the `auxiliary-data/modeled-clades/` directory of the repository and will be named “YYYY-MM-DD.json” where “YYYY-MM-DD” is the date of the Wednesday on which submissions are due.
 
 This clade selection is based on the ["full open" NextStrain sequence metadata files](https://docs.nextstrain.org/projects/ncov/en/latest/reference/remote_inputs.html#remote-inputs-open-files), in particular [this file](https://data.nextstrain.org/files/ncov/open/metadata.tsv.zst) which is loaded and analyzed using [this script](https://github.com/reichlab/virus-clade-utils/blob/main/src/virus_clade_utils/get_clade_list.py). The NextStrain files are [typically updated daily in the late evening US eastern time](https://github.com/nextstrain/forecasts-ncov/actions/workflows/update-ncov-open-clade-counts.yaml) (it is only updated when new data are available). The hub pulls the most recent version of the file when the workflow runs each week. The precise lineage assignment model (sometimes referred to as a “reference tree”) that was used as well as the version of raw sequence data is stored as metadata, to facilitate reproducibility and evaluation. 
 

--- a/hub-config/model-metadata-schema.json
+++ b/hub-config/model-metadata-schema.json
@@ -1,13 +1,9 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "title": "Schema for Modeling Hub model metadata",
-    "description": "This is the schema for model metadata files, please refer to https://github.com/covid19-forecast-hub-europe/covid19-forecast-hub-europe/wiki/Metadata for more information.",
+    "title": "Schema for SARS-CoV-2 Variant Nowcast Hub model metadata",
+    "description": "This is the schema for model metadata files, please refer to https://github.com/reichlab/variant-nowcast-hub/blob/main/README.md#model-metadata for more information.",
     "type": "object",
     "properties": {
-        "schema_version": {
-            "type": "string",
-            "format": "uri"
-        },
         "team_name": {
             "description": "The name of the team submitting the model",
             "type": "string"
@@ -29,7 +25,7 @@
             "maxLength": 16
         },
         "model_version": {
-            "description": "Identifier of the version of the model",
+            "description": "Identifier of the version of the model, if multiple versions are present.",
             "type": "string"
         },
         "model_contributors": {
@@ -43,19 +39,21 @@
                     "affiliation": {
                         "type": "string"
                     },
-                    "orcid": {
-                        "type": "string",
-                        "pattern": "^\\d{4}\\-\\d{4}\\-\\d{4}\\-[\\dX]{4}$"
-                    },
                     "email": {
                         "type": "string",
                         "format": "email"
                     },
-                    "twitter": {
-                        "type": "string"
-                    },
-                    "additionalProperties": false
-                }
+                    "orcid": {
+                        "type": "string",
+                        "pattern": "^\\d{4}\\-\\d{4}\\-\\d{4}\\-[\\dX]{4}$"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "affiliation",
+                    "email"
+                ]
             }
         },
         "website_url": {
@@ -84,48 +82,42 @@
         "citation": {
             "description": "One or more citations for this model",
             "type": "string",
-            "examples": "Gibson GC , Reich NG , Sheldon D. Real-time mechanistic bayesian forecasts of Covid-19 mortality. medRxiv. 2020. https://doi.org/10.1101/2020.12.22.20248736"
+            "examples": ["Gibson GC , Reich NG , Sheldon D. Real-time mechanistic bayesian forecasts of Covid-19 mortality. medRxiv. 2020. https://doi.org/10.1101/2020.12.22.20248736"]
         },
         "team_funding": {
             "description": "Any information about funding source for the team or members of the team.",
             "type": "string",
-            "examples": "National Institutes of General Medical Sciences (R01GM123456). The content is solely the responsibility of the authors and does not necessarily represent the official views of NIGMS."
+            "examples": ["National Institutes of General Medical Sciences (R01GM123456). The content is solely the responsibility of the authors and does not necessarily represent the official views of NIGMS."]
         },
-        "model_details": {
-            "description": "Structured information about the model",
-            "type": "object",
-            "properties": {
-                "data_inputs": {
-                    "description": "List or description of data inputs used by the model",
-                    "type": "string"
-                },
-                "methods": {
-                    "description": "A brief (200 char.) description of the methods used by this model",
-                    "type": "string",
-                    "maxLength": 200
-                },
-                "methods_long": {
-                    "description": "A full description of the methods used by this model.",
-                    "type": "string"
-                }
-            },
-            "additionalProperties": false,
-            "required": ["data_inputs", "methods"]
+        "methods": {
+            "description": "A brief (200 char.) description of the methods used by this model",
+            "type": "string",
+            "maxLength": 200
+        },
+        "methods_long": {
+            "description": "A full description of the methods used by this model. Among other details, this should include details about the joint dependence structure of the model, and across what variables the model draws joint distributions, e.g., across horizons but not horizons and locations.",
+            "type": "string"
+        },
+        "ensemble_of_models": {
+            "description": "Indicator for whether this model is an ensemble of any separate component models",
+            "type": "boolean"
         },
         "ensemble_of_hub_models": {
-            "description": "Indicator for whether this model is an ensemble of other Hub models",
+            "description": "Indicator for whether this model is an ensemble specifically of other models submitted to this Hub",
             "type": "boolean"
         }
     },
-    "additionalProperties": true,
+    "additionalProperties": false,
     "required": [
-        "schema_version",
         "team_name",
         "team_abbr",
         "model_name",
         "model_abbr",
         "model_contributors",
         "license",
-        "model_details"
+        "methods",
+        "methods_long",
+        "ensemble_of_models",
+        "ensemble_of_hub_models"
     ]
 }

--- a/hub-config/model-metadata-schema.json
+++ b/hub-config/model-metadata-schema.json
@@ -90,12 +90,16 @@
             "examples": ["National Institutes of General Medical Sciences (R01GM123456). The content is solely the responsibility of the authors and does not necessarily represent the official views of NIGMS."]
         },
         "methods": {
-            "description": "A brief (200 char.) description of the methods used by this model",
+            "description": "A summary of the methods used by this model (5000 character limit). Among other details, this should include details about the joint dependence structure of the model, and across what variables the model draws joint distributions, e.g., across horizons but not horizons and locations.",
             "type": "string",
-            "maxLength": 200
+            "maxLength": 5000
         },
-        "methods_long": {
-            "description": "A full description of the methods used by this model. Among other details, this should include details about the joint dependence structure of the model, and across what variables the model draws joint distributions, e.g., across horizons but not horizons and locations.",
+        "methods_url": {
+            "description": "A link to a complete write-up of the model specification, with mathematical details. This could be a peer-reviewed article, preprint, or an unpublished PDF or webpage stored at a public url somewhere.",
+            "type": "uri"
+        },
+        "data_sources": {
+            "description": "List or description of data inputs used by the model. For example:  NextStrain, GISAID for sequences outside of the U.S., wastewater variant proportions, etc....",
             "type": "string"
         },
         "ensemble_of_models": {
@@ -117,6 +121,8 @@
         "license",
         "methods",
         "methods_long",
+        "methods_url",
+        "data_sources",
         "ensemble_of_models",
         "ensemble_of_hub_models"
     ]


### PR DESCRIPTION
This is a draft model metadata schema file. Are there additional fields or instructions we want to include? 

This version passes schema/config validation:
```
> validate_hub_config()
...
── $model-metadata-schema 
[1] TRUE
✔ ok:  hub-config/model-metadata-schema.json (from default json schema )
```

Note that this, along with #60 is related to #34 