### PR TITLE
use correct argument for setup-r action

### DIFF
--- a/.github/workflows/create-modeling-round.yaml
+++ b/.github/workflows/create-modeling-round.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up R 📊
         uses: r-lib/actions/setup-r@v2
         with:
-          setup-r: false
+          install-r: false
           use-public-rspm: true
           extra-repositories: 'https://hubverse-org.r-universe.dev'
 


### PR DESCRIPTION
My brain does not like to brain well today. This fixes the action so that it uses the system version of R instead of trying to re-install R from scratch every time.