### PR TITLE
Bsweger/update clade list/41

### DIFF
--- a/auxiliary-data/modeled-clades/2024-09-11.json
+++ b/auxiliary-data/modeled-clades/2024-09-11.json
@@ -1,0 +1,10 @@
+{
+    "clades": [
+        "24A",
+        "24B",
+        "24C",
+        "recombinant",
+        "other"
+    ],
+    "meta": {}
+}

--- a/auxiliary-data/modeled-clades/2024-09-11.txt
+++ b/auxiliary-data/modeled-clades/2024-09-11.txt
@@ -1,5 +1,0 @@
-24A
-24B
-24C
-recombinant
-other

--- a/auxiliary-data/modeled-clades/2024-09-18.json
+++ b/auxiliary-data/modeled-clades/2024-09-18.json
@@ -1,0 +1,10 @@
+{
+    "clades": [
+        "24A",
+        "24B",
+        "24C",
+        "recombinant",
+        "other"
+    ],
+    "meta": {}
+}

--- a/auxiliary-data/modeled-clades/2024-09-18.txt
+++ b/auxiliary-data/modeled-clades/2024-09-18.txt
@@ -1,5 +1,0 @@
-24A
-24B
-24C
-recombinant
-other

--- a/auxiliary-data/modeled-clades/2024-09-25.json
+++ b/auxiliary-data/modeled-clades/2024-09-25.json
@@ -1,0 +1,10 @@
+{
+    "clades": [
+        "24A",
+        "24B",
+        "24C",
+        "recombinant",
+        "other"
+    ],
+    "meta": {}
+}

--- a/auxiliary-data/modeled-clades/2024-09-25.txt
+++ b/auxiliary-data/modeled-clades/2024-09-25.txt
@@ -1,5 +1,0 @@
-24A
-24B
-24C
-recombinant
-other

--- a/auxiliary-data/modeled-clades/2024-10-02.json
+++ b/auxiliary-data/modeled-clades/2024-10-02.json
@@ -1,0 +1,11 @@
+{
+    "clades": [
+        "24A",
+        "24B",
+        "24C",
+        "24E",
+        "recombinant",
+        "other"
+    ],
+    "meta": {}
+}

--- a/auxiliary-data/modeled-clades/2024-10-02.txt
+++ b/auxiliary-data/modeled-clades/2024-10-02.txt
@@ -1,6 +1,0 @@
-24A
-24B
-24C
-24E
-recombinant
-other

--- a/hub-config/tasks.json
+++ b/hub-config/tasks.json
@@ -22,7 +22,7 @@
               "optional": ["AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "DC", "FL", "GA", "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD", "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", "RI", "SC", "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY", "PR"]
             },
             "clade": {
-              "required": ["24A", "24B", "24C", "other", "recombinant"],
+              "required": ["24A", "24B", "24C", "recombinant", "other"],
               "optional": null
             }
           },
@@ -95,7 +95,7 @@
               "optional": ["AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "DC", "FL", "GA", "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD", "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", "RI", "SC", "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY", "PR"]
             },
             "clade": {
-              "required": ["24A", "24B", "24C", "other", "recombinant"],
+              "required": ["24A", "24B", "24C", "recombinant", "other"],
               "optional": null
             }
           },
@@ -168,7 +168,7 @@
               "optional": ["AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "DC", "FL", "GA", "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD", "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", "RI", "SC", "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY", "PR"]
             },
             "clade": {
-              "required": ["24A", "24B", "24C", "other", "recombinant"],
+              "required": ["24A", "24B", "24C", "recombinant", "other"],
               "optional": null
             }
           },
@@ -241,7 +241,7 @@
               "optional": ["AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "DC", "FL", "GA", "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD", "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", "RI", "SC", "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY", "PR"]
             },
             "clade": {
-              "required": ["24A", "24B", "24C", "24E", "other", "recombinant"],
+              "required": ["24A", "24B", "24C", "24E", "recombinant", "other"],
               "optional": null
             }
           },

--- a/src/get_clades_to_model.py
+++ b/src/get_clades_to_model.py
@@ -25,6 +25,7 @@ To run the script manually:
 # ]
 # ///
 
+import json
 import logging
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -57,15 +58,20 @@ def get_next_wednesday(starting_date: datetime) -> str:
 def main(round_id: str, clade_output_path: Path):
     """Get a list of clades to model and save to the hub's auxiliary-data folder."""
 
+    round_data = {}
+
     clade_list = get_clade_list.main()
     clade_list.sort()
+    clade_list.append("other")
+    round_data["clades"] = clade_list
     logger.info(f"Clade list: {clade_list}")
 
-    clade_file = clade_output_path / f"{round_id}.txt"
+    round_data["clade_list"] = clade_list
+    round_data["meta"] = {}
+
+    clade_file = clade_output_path / f"{round_id}.json"
     with open(clade_file, "w") as f:
-        for clade in clade_list:
-            f.write(f"{clade}\n")
-        f.write("other\n")
+        json.dump(round_data, f, indent=4)
 
     logger.info(f"Clade list saved: {clade_file}")
 

--- a/src/get_clades_to_model.py
+++ b/src/get_clades_to_model.py
@@ -21,15 +21,17 @@ To run the script manually:
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#   "virus_clade_utils@git+https://github.com/reichlab/virus-clade-utils/",
+#   "virus_clade_utils@git+https://github.com/reichlab/virus-clade-utils@bsweger/get_nextstrain_ncov_metadata",
 # ]
 # ///
 
 import json
 import logging
+from collections import defaultdict
 from datetime import datetime, timedelta
 from pathlib import Path
 
+from virus_clade_utils.cladetime import CladeTime  # type: ignore
 from virus_clade_utils import get_clade_list  # type: ignore
 
 # Log to stdout
@@ -58,16 +60,22 @@ def get_next_wednesday(starting_date: datetime) -> str:
 def main(round_id: str, clade_output_path: Path):
     """Get a list of clades to model and save to the hub's auxiliary-data folder."""
 
-    round_data = {}
+    round_data: defaultdict[str, dict] = defaultdict(dict)
 
+    # Get the clade list
     clade_list = get_clade_list.main()
     clade_list.sort()
     clade_list.append("other")
     round_data["clades"] = clade_list
     logger.info(f"Clade list: {clade_list}")
 
-    round_data["clade_list"] = clade_list
-    round_data["meta"] = {}
+    # Get metadata about the Nextstrain ncov pipeline run that
+    # the clade list is based on
+    ct = CladeTime()
+    ncov_meta = ct.ncov_metadata
+    ncov_meta["metadata_version_url"] = ct.url_ncov_metadata
+    round_data["meta"]["ncov"] = ncov_meta
+    logger.info(f"Ncov metadata: {ncov_meta}")
 
     clade_file = clade_output_path / f"{round_id}.json"
     with open(clade_file, "w") as f:

--- a/src/get_clades_to_model.py
+++ b/src/get_clades_to_model.py
@@ -21,7 +21,7 @@ To run the script manually:
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#   "virus_clade_utils@git+https://github.com/reichlab/virus-clade-utils@bsweger/get_nextstrain_ncov_metadata",
+#   "virus_clade_utils@git+https://github.com/reichlab/virus-clade-utils",
 # ]
 # ///
 

--- a/src/make_round_config.R
+++ b/src/make_round_config.R
@@ -13,6 +13,7 @@ library(cli)
 library(here)
 library(hubAdmin)
 library(hubUtils)
+library(jsonlite)
 library(lobstr)
 library(tools)
 
@@ -35,18 +36,6 @@ get_latest_clade_file <- function(hub_dir) {
   return(clade_file_info)
 }
 
-#' Return the clades that modelers will predict in the new round
-#'
-#' @description
-#' `get_clade_list` reads the hub's latest clade file and returns a list
-#' of the SARS-CoV-2 clades that will be required in the round's clade task_id.
-#'
-#' @param filename Character vector. Full path to the hub's latest clade file.
-#' @returns A list with one element that contains the clades to be modeled.
-get_clade_list <- function(filename) {
-  clade_list <- readLines(filename)
-  return(clade_list)
-}
 
 #' Create a new round object
 #'
@@ -58,7 +47,7 @@ get_clade_list <- function(filename) {
 #' @returns A round object.
 create_new_round <- function(hub_root) {
   this_round_clade_file <- get_latest_clade_file(hub_root)
-  this_round_clade_list <- sort(get_clade_list(this_round_clade_file$clade_file))
+  this_round_clade_list <- fromJSON(this_round_clade_file$clade_file)$clades
   this_round_date <- this_round_clade_file$round_id
   if (isFALSE(weekdays(as.Date(this_round_date)) == "Wednesday")) {
     stop("The latest clade_file does not have a Wednesday date: ", this_round_clade_file)


### PR DESCRIPTION
Closes #41 

## Background

- Rather than writing .txt files with clade news to `auxiliary-data/modeled-clades`, write .json (same filename format, just YYYY-MM-DD.json instead of YYYY-MM-DD.txt)
- Add metadata to the .json file that we'll need to find the reference tree in use at the time we generated the clade list
- More information: #41 

## Additional Review Notes

- The PR replaces all former .txt files in `auxiliary-data/modeled-clades` with their updated .json versions
- The `meta` key of the re-generated .json files is empty, since we weren't pull metadata in prior weeks
- Example of the artifacts generated via the GitHub action (this is similar to what next Monday's scheduled run will produce): https://github.com/reichlab/variant-nowcast-hub/pull/89/commits/3a700ae80831ab031c1fc043bed44ed00875849a

