### PR TITLE
Add files to open the 2024-10-16 round

### DIFF
--- a/auxiliary-data/modeled-clades/2024-10-16.json
+++ b/auxiliary-data/modeled-clades/2024-10-16.json
@@ -1,0 +1,21 @@
+{
+    "clades": [
+        "24A",
+        "24B",
+        "24C",
+        "24E",
+        "recombinant",
+        "other"
+    ],
+    "meta": {
+        "ncov": {
+            "schema_version": "v1",
+            "nextclade_version": "nextclade 3.8.2",
+            "nextclade_dataset_name": "SARS-CoV-2",
+            "nextclade_dataset_version": "2024-09-25--21-50-30Z",
+            "nextclade_tsv_sha256sum": "e95fb39783035a4c68f45f0d3d89000da395c644a541be681115cb6882f71140",
+            "metadata_tsv_sha256sum": "b859ddd3ad4a5aa164f8487911d985edcb60132cff7b01ef5cf4c41d28998884",
+            "metadata_version_url": "https://nextstrain-data.s3.amazonaws.com/files/ncov/open/metadata_version.json?versionId=P2ijkcwYp39968vQcie1pDGe6Oud03N."
+        }
+    }
+}

--- a/hub-config/tasks.json
+++ b/hub-config/tasks.json
@@ -365,6 +365,79 @@
         "start": -2,
         "end": 1
       }
+    },
+    {
+      "round_id_from_variable": true,
+      "round_id": "nowcast_date",
+      "model_tasks": [
+        {
+          "task_ids": {
+            "nowcast_date": {
+              "required": [
+                "2024-10-16"
+              ],
+              "optional": null
+            },
+            "target_date": {
+              "required": null,
+              "optional": ["2024-09-15", "2024-09-16", "2024-09-17", "2024-09-18", "2024-09-19", "2024-09-20", "2024-09-21", "2024-09-22", "2024-09-23", "2024-09-24", "2024-09-25", "2024-09-26", "2024-09-27", "2024-09-28", "2024-09-29", "2024-09-30", "2024-10-01", "2024-10-02", "2024-10-03", "2024-10-04", "2024-10-05", "2024-10-06", "2024-10-07", "2024-10-08", "2024-10-09", "2024-10-10", "2024-10-11", "2024-10-12", "2024-10-13", "2024-10-14", "2024-10-15", "2024-10-16", "2024-10-17", "2024-10-18", "2024-10-19", "2024-10-20", "2024-10-21", "2024-10-22", "2024-10-23", "2024-10-24", "2024-10-25", "2024-10-26"]
+            },
+            "location": {
+              "required": null,
+              "optional": ["AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "DC", "FL", "GA", "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD", "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", "RI", "SC", "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY", "PR"]
+            },
+            "clade": {
+              "required": ["24A", "24B", "24C", "24E", "recombinant", "other"],
+              "optional": null
+            }
+          },
+          "output_type": {
+            "mean": {
+              "output_type_id": {
+                "required": null,
+                "optional": [
+                  "NA"
+                ]
+              },
+              "value": {
+                "type": "double",
+                "minimum": 0,
+                "maximum": 1
+              }
+            },
+            "sample": {
+              "output_type_id_params": {
+                "is_required": false,
+                "type": "character",
+                "max_length": 15,
+                "min_samples_per_task": 100,
+                "max_samples_per_task": 100
+              },
+              "value": {
+                "type": "double",
+                "minimum": 0,
+                "maximum": 1
+              }
+            }
+          },
+          "target_metadata": [
+            {
+              "target_id": "clade prop",
+              "target_name": "Daily nowcasted clade proportions",
+              "target_units": "proportion",
+              "target_keys": null,
+              "target_type": "compositional",
+              "is_step_ahead": true,
+              "time_unit": "day"
+            }
+          ]
+        }
+      ],
+      "submissions_due": {
+        "relative_to": "nowcast_date",
+        "start": -2,
+        "end": 1
+      }
     }
   ]
 }


### PR DESCRIPTION
This PR contains the updated `tasks.json` and clade list for the `2024-10-16` round.

(The [scheduled GitHub action failed](https://github.com/reichlab/variant-nowcast-hub/actions/runs/11320325287/job/31477699744), so I generated these files manually)