### PR TITLE
Update src/ scripts for compatibility with Cladetime API

### DIFF
--- a/src/get_clades_to_model.py
+++ b/src/get_clades_to_model.py
@@ -33,8 +33,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 import polars as pl
-from cladetime import CladeTime  # type: ignore
-from cladetime.util.sequence import filter_covid_genome_metadata, get_clade_counts  # type: ignore
+from cladetime import CladeTime, sequence  # type: ignore
 
 # Log to stdout
 logger = logging.getLogger(__name__)
@@ -125,8 +124,10 @@ def main(
     logger.info("Getting clade list")
     ct = CladeTime()
     lf_metadata = ct.sequence_metadata
-    lf_metadata_filtered = filter_covid_genome_metadata(lf_metadata)
-    counts = get_clade_counts(lf_metadata_filtered)
+    lf_metadata_filtered = sequence.filter_metadata(lf_metadata)
+    counts = sequence.summarize_clades(
+        lf_metadata_filtered, group_by=["clade", "date", "location"]
+    )
     clade_list = get_clades(counts, threshold, threshold_weeks, max_clades)
 
     # Sort clade list and add "other"

--- a/src/get_clades_to_model.py
+++ b/src/get_clades_to_model.py
@@ -28,9 +28,9 @@ To run the script manually:
 
 import json
 import logging
-from collections import defaultdict
 from datetime import datetime, timedelta
 from pathlib import Path
+from typing import TypedDict
 
 import polars as pl
 from cladetime import CladeTime, sequence  # type: ignore
@@ -118,7 +118,9 @@ def main(
 ):
     """Get a list of clades to model and save to the hub's auxiliary-data folder."""
 
-    round_data: defaultdict[str, dict] = defaultdict(dict)
+    class RoundData(TypedDict):
+        clades: list[str]
+        meta: dict[str, dict]
 
     # Get the clade list
     logger.info("Getting clade list")
@@ -133,15 +135,15 @@ def main(
     # Sort clade list and add "other"
     clade_list.sort()
     clade_list.append("other")
-    round_data["clades"] = clade_list
     logger.info(f"Clade list: {clade_list}")
 
     # Get metadata about the Nextstrain ncov pipeline run that
     # the clade list is based on
     ncov_meta = ct.ncov_metadata
     ncov_meta["metadata_version_url"] = ct.url_ncov_metadata
-    round_data["meta"]["ncov"] = ncov_meta
     logger.info(f"Ncov metadata: {ncov_meta}")
+
+    round_data: RoundData = {"clades": clade_list, "meta": {"ncov": ncov_meta}}
 
     clade_file = clade_output_path / f"{round_id}.json"
     with open(clade_file, "w") as f:

--- a/src/get_location_date_counts.py
+++ b/src/get_location_date_counts.py
@@ -26,8 +26,7 @@ from pathlib import Path
 from zoneinfo import ZoneInfo
 
 import polars as pl
-from cladetime import CladeTime  # type: ignore
-from cladetime.util.sequence import filter_covid_genome_metadata  # type: ignore
+from cladetime import CladeTime, sequence  # type: ignore
 
 # Log to stdout
 logger = logging.getLogger(__name__)
@@ -76,7 +75,7 @@ def get_location_date_counts(
 
     # Apply the same filters we used to create the list of clade
     # target data for the round (e.g., USA, human host)
-    filtered = filter_covid_genome_metadata(sequence_metadata)
+    filtered = sequence.filter_metadata(sequence_metadata)
 
     # Create a LazyFrame with all combinations of states and the
     # dates we're interested in (in this case, 31 days prior to
@@ -113,7 +112,7 @@ def test_counts(round_close_time: datetime, computed_counts: pl.DataFrame):
     # Get all rows in sequence metadata that have reported a sequence
     # with a collection date in the 31 days prior to round_close
     begin_date = round_close_time.date() - timedelta(days=31)
-    test_data = filter_covid_genome_metadata(ct.sequence_metadata)
+    test_data = sequence.filter_metadata(ct.sequence_metadata)
     test_data = test_data.filter(pl.col("date") >= begin_date).collect(streaming=True)
 
     assert test_data.height == computed_counts["count"].sum()


### PR DESCRIPTION
Closes #153 

This PR makes some updates to reflect `cladetime` API changes. Thus far, we've been ensuring that [cladetime maintains backward compatibility](https://github.com/reichlab/cladetime/blob/main/src/cladetime/util/sequence.py), but we'd like to remove that workaround, which makes the cladetime code base more confusing.

There's also a change to address a warning message from Python's static type checker.

The GitHub actions for both impacted scripts ran successfully in a test:

- [sequence counts by location and date](https://github.com/reichlab/variant-nowcast-hub/pull/155)
- [get a list of clades to model](https://github.com/reichlab/variant-nowcast-hub/pull/154)