### PR TITLE
Add a check to ensure AWS uploads don't run on forks

### DIFF
--- a/.github/workflows/hubverse-aws-upload.yaml
+++ b/.github/workflows/hubverse-aws-upload.yaml
@@ -16,6 +16,8 @@ permissions:
 
 jobs:
   upload:
+    # Don't run on forked repositories
+    if: github.event.repository.fork != true
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This commit is part of addressing an issue for detecting forks https://github.com/hubverse-org/hubverse-actions/issues/25

It modifies the hubverse-aws-upload action to skip the S3 upload if the repo is a fork. The goal of trying it here first is to ensure that it works as expected on a hub that we manage (before submitting the change to the [hubverse-actions repo](https://github.com/hubverse-org/hubverse-actions/blob/main/hubverse-aws-upload/hubverse-aws-upload.yaml) and to the CDC's flu hub)

Can confirm that this change prevented the action from running on my fork: https://github.com/bsweger/variant-nowcast-hub/actions/runs/12144218061