### PR TITLE
Pin polars library to an earlier version

### DIFF
--- a/src/get_clades_to_model.py
+++ b/src/get_clades_to_model.py
@@ -22,7 +22,7 @@ To run the script manually:
 # requires-python = ">=3.11"
 # dependencies = [
 #   "cladetime@git+https://github.com/reichlab/cladetime",
-#   "polars",
+#   "polars==1.6.0",
 # ]
 # ///
 


### PR DESCRIPTION
This PR pins an older version of polars (1.6 is what's currently installed on my machine) as a temporary fix for the kernal panic error that yesterdays' scheduled "open round" workflow received.

A test workflow run against this branch completed successfully: https://github.com/reichlab/variant-nowcast-hub/actions/runs/12237520262/job/34133455577