### PR TITLE
Adjust the Polars version to reflect the patched version

### DIFF
--- a/src/get_clades_to_model.py
+++ b/src/get_clades_to_model.py
@@ -22,7 +22,7 @@ To run the script manually:
 # requires-python = ">=3.11"
 # dependencies = [
 #   "cladetime@git+https://github.com/reichlab/cladetime",
-#   "polars==1.6.0",
+#   "polars>=1.17.1,<1.18.0",
 # ]
 # ///
 

--- a/src/get_location_date_counts.py
+++ b/src/get_location_date_counts.py
@@ -16,6 +16,7 @@ To run the script manually:
 # requires-python = ">=3.11"
 # dependencies = [
 #   "cladetime@git+https://github.com/reichlab/cladetime",
+#   "polars>=1.17.1,<1.18.0",
 # ]
 # ///
 


### PR DESCRIPTION
[Polars 1.17.1 fixes the scratch.is_empty() panic](https://github.com/pola-rs/polars/releases/tag/py-1.17.1) that was impacting variant-nowcast scripts that run Cladetime.

Now that Polars released a fix, we don't strictly need to pin the Polars version, but I added the < 1.18 so we're not caught unawares by the next .0 release.

Note that get_location_date_counts previously imported polars via the cladetime dependency, but it should import polars explicitly.