### PR TITLE
bsweger/add created at metadata/201

### DIFF
--- a/auxiliary-data/modeled-clades/2024-10-09.json
+++ b/auxiliary-data/modeled-clades/2024-10-09.json
@@ -8,6 +8,7 @@
         "other"
     ],
     "meta": {
+        "created_at": "2024-10-07T03:12:13+00:00",
         "ncov": {
             "schema_version": "v1",
             "nextclade_version": "nextclade 3.8.2",

--- a/auxiliary-data/modeled-clades/2024-10-16.json
+++ b/auxiliary-data/modeled-clades/2024-10-16.json
@@ -8,7 +8,7 @@
         "other"
     ],
     "meta": {
-        "created_at": "2024-10-16T19:37:00+00:00",
+        "created_at": "2024-10-15T19:37:00+00:00",
         "ncov": {
             "schema_version": "v1",
             "nextclade_version": "nextclade 3.8.2",

--- a/auxiliary-data/modeled-clades/2024-10-16.json
+++ b/auxiliary-data/modeled-clades/2024-10-16.json
@@ -8,6 +8,7 @@
         "other"
     ],
     "meta": {
+        "created_at": "2024-10-16T19:37:00+00:00",
         "ncov": {
             "schema_version": "v1",
             "nextclade_version": "nextclade 3.8.2",

--- a/auxiliary-data/modeled-clades/2024-10-23.json
+++ b/auxiliary-data/modeled-clades/2024-10-23.json
@@ -10,6 +10,7 @@
         "other"
     ],
     "meta": {
+        "created_at": "2024-10-21T03:16:32+00:00",
         "ncov": {
             "schema_version": "v1",
             "nextclade_version": "nextclade 3.8.2",

--- a/auxiliary-data/modeled-clades/2024-10-30.json
+++ b/auxiliary-data/modeled-clades/2024-10-30.json
@@ -10,6 +10,7 @@
         "other"
     ],
     "meta": {
+        "created_at": "2024-10-28T03:14:57+00:00",
         "ncov": {
             "schema_version": "v1",
             "nextclade_version": "nextclade 3.9.0",

--- a/auxiliary-data/modeled-clades/2024-11-06.json
+++ b/auxiliary-data/modeled-clades/2024-11-06.json
@@ -10,6 +10,7 @@
         "other"
     ],
     "meta": {
+        "created_at": "2024-11-04T19:58:15+00:00",
         "ncov": {
             "schema_version": "v1",
             "nextclade_version": "nextclade 3.9.1",

--- a/auxiliary-data/modeled-clades/2024-11-13.json
+++ b/auxiliary-data/modeled-clades/2024-11-13.json
@@ -10,6 +10,7 @@
         "other"
     ],
     "meta": {
+        "created_at": "2024-11-11T03:10:59+00:00",
         "ncov": {
             "schema_version": "v1",
             "nextclade_version": "nextclade 3.9.1",

--- a/auxiliary-data/modeled-clades/2024-11-20.json
+++ b/auxiliary-data/modeled-clades/2024-11-20.json
@@ -12,6 +12,7 @@
         "other"
     ],
     "meta": {
+        "created_at": "2024-11-18T03:18:39+00:00",
         "ncov": {
             "schema_version": "v1",
             "nextclade_version": "nextclade 3.9.1",

--- a/auxiliary-data/modeled-clades/2024-11-27.json
+++ b/auxiliary-data/modeled-clades/2024-11-27.json
@@ -12,6 +12,7 @@
         "other"
     ],
     "meta": {
+        "created_at": "2024-11-25T16:32:17+00:00",
         "ncov": {
             "schema_version": "v1",
             "nextclade_version": "nextclade 3.9.1",

--- a/auxiliary-data/modeled-clades/2024-12-04.json
+++ b/auxiliary-data/modeled-clades/2024-12-04.json
@@ -12,6 +12,7 @@
         "other"
     ],
     "meta": {
+        "created_at": "2024-12-02T03:20:52+00:00",
         "ncov": {
             "schema_version": "v1",
             "nextclade_version": "nextclade 3.9.1",

--- a/auxiliary-data/modeled-clades/2024-12-11.json
+++ b/auxiliary-data/modeled-clades/2024-12-11.json
@@ -11,6 +11,7 @@
         "other"
     ],
     "meta": {
+        "created_at": "2024-12-09T14:31:17+00:00",
         "ncov": {
             "schema_version": "v1",
             "nextclade_version": "nextclade 3.9.1",

--- a/src/get_clades_to_model.py
+++ b/src/get_clades_to_model.py
@@ -28,7 +28,7 @@ To run the script manually:
 
 import json
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TypedDict
 
@@ -120,7 +120,9 @@ def main(
 
     class RoundData(TypedDict):
         clades: list[str]
-        meta: dict[str, dict]
+        meta: dict[str, dict | str]
+
+    current_time = datetime.now(timezone.utc).isoformat(timespec="seconds")
 
     # Get the clade list
     logger.info("Getting clade list")
@@ -143,7 +145,10 @@ def main(
     ncov_meta["metadata_version_url"] = ct.url_ncov_metadata
     logger.info(f"Ncov metadata: {ncov_meta}")
 
-    round_data: RoundData = {"clades": clade_list, "meta": {"ncov": ncov_meta}}
+    round_data: RoundData = {
+        "clades": clade_list,
+        "meta": {"created_at": current_time, "ncov": ncov_meta},
+    }
 
     clade_file = clade_output_path / f"{round_id}.json"
     with open(clade_file, "w") as f:


### PR DESCRIPTION
Closes #201 

We need to log the timestamp of when the weekly clade list is created (so we can use that date/time to specify the correct reference tree when generating target data).

This PR updates the script that creates the weekly clade .json in `auxiliary-data/modeled-clades`.

It also retroactively adds the new `created_at` field to the clade list for prior rounds (using the timestamps from the associated PRs, which are linked in the individual commit messages).