### PR TITLE
add a compound_taskid_set to sample output_type_id_params

### DIFF
--- a/src/make_round_config.R
+++ b/src/make_round_config.R
@@ -104,6 +104,7 @@ create_new_round <- function(hub_root) {
           max_length = 15L,
           min_samples_per_task = 100L,
           max_samples_per_task = 100L,
+          compound_taskid_set = c("nowcast_date", "location"),
           value_type = "double",
           value_minimum = 0L,
           value_maximum = 1L,


### PR DESCRIPTION
Closes #205

(also see #202, the issue that tested this updated configuration using model-output submissions from UGA and UMass)

After running the updated script locally, the `sample` block of `output_type` looks like this:

```json
           "sample": {
              "output_type_id_params": {
                "is_required": false,
                "type": "character",
                "max_length": 15,
                "min_samples_per_task": 100,
                "max_samples_per_task": 100,
                "compound_taskid_set": ["nowcast_date", "location"]
              },
              "value": {
                "type": "double",
                "minimum": 0,
                "maximum": 1
              }
            }
```