### PR TITLE
Update Wednesday evening GitHub workflow to generate target data

### DIFF
--- a/.github/actions/create-pr/action.yml
+++ b/.github/actions/create-pr/action.yml
@@ -1,0 +1,48 @@
+name: Submit PR
+description: Submit a PR with files created by the invoking GitHub workflow
+
+inputs:
+  pr-prefix:
+    description: "Prefix for PR branch and title"
+    required: true
+  file-path:
+    description: "Path to the file(s) to commit"
+    required: true
+  commit-message:
+    description: "Commit message"
+    required: true
+  pr-body:
+    description: "Description of the PR"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get current date and time
+      shell: bash
+      run: |
+        PR_DATETIME=$(date +'%Y-%m-%d_%H-%M-%S')
+        echo "PR_DATETIME=$PR_DATETIME" >> $GITHUB_ENV
+
+    - name: Create PR
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        # debug stuff
+        echo "Current directory: $(pwd)"
+        echo "Checking file exists:"
+        ls -la ${{ inputs.file-path }}
+        echo "Git status:"
+        git status
+
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git checkout -b ${{ inputs.pr-prefix }}_"$PR_DATETIME"
+        git add ${{ inputs.file-path }}
+        git commit -m "${{ inputs.commit-message }} $PR_DATETIME"
+        git push -u origin HEAD
+        gh pr create \
+          --base main \
+          --title "${{ inputs.pr-prefix }} $PR_DATETIME" \
+          --body "${{ inputs.pr-body }}"

--- a/.github/actions/create-pr/action.yml
+++ b/.github/actions/create-pr/action.yml
@@ -18,7 +18,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Get current date and time
+    - name: Get current date and time ⏰
       shell: bash
       run: |
         PR_DATETIME=$(date +'%Y-%m-%d_%H-%M-%S')

--- a/.github/actions/create-pr/action.yml
+++ b/.github/actions/create-pr/action.yml
@@ -40,6 +40,13 @@ runs:
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git checkout -b ${{ inputs.pr-prefix }}_"$PR_DATETIME"
         git add ${{ inputs.file-path }}
+
+        # if there are no changes to commit, exit
+        if git diff --staged --quiet; then
+          echo "No changes to commit in ${{ inputs.file-path }}"
+          exit 0
+        fi
+
         git commit -m "${{ inputs.commit-message }} $PR_DATETIME"
         git push -u origin HEAD
         gh pr create \

--- a/.github/shared/shared-functions.sh
+++ b/.github/shared/shared-functions.sh
@@ -1,0 +1,9 @@
+# shared bash functions to use in workflows
+
+get_latest_wednesday() {
+    if [ $(date +%u) -eq 3 ]; then
+    date +%Y-%m-%d
+    else
+    date -d'last wednesday' +%Y-%m-%d
+    fi
+}

--- a/.github/shared/shared-functions.sh
+++ b/.github/shared/shared-functions.sh
@@ -1,9 +1,14 @@
 # shared bash functions to use in workflows
 
 get_latest_wednesday() {
-    if [ $(date +%u) -eq 3 ]; then
-    date +%Y-%m-%d
+    local input_date="$1"
+    if [ -n "$input_date" ]; then
+        echo "$input_date"
     else
-    date -d'last wednesday' +%Y-%m-%d
+        if [ $(date +%u) -eq 3 ]; then
+            date +%Y-%m-%d
+        else
+            date -d'last wednesday' +%Y-%m-%d
+        fi
     fi
 }

--- a/.github/workflows/create-location-date-sequence-counts.yaml
+++ b/.github/workflows/create-location-date-sequence-counts.yaml
@@ -1,4 +1,7 @@
-name: Create a file of sequence counts by location and collection date
+# This workflow is designed to run shortly after the hub's weekly submission
+# deadline. It generates an unscored-location-dates file as well as time
+# series and oracle output target data.
+name: Run post-submission close jobs
 
 on:
   schedule:
@@ -6,12 +9,67 @@ on:
     - cron: "20 01 * 11-12,1-3 4" # 1:20 AM UTC every Thurs (Nov-Dec, Jan-Mar)
     - cron: "20 00 * 4-10 4" # 12:20 AM UTC every Thurs (Apr-Oct)
   workflow_dispatch:
+    inputs:
+      nowcast_date:
+        description: "Nowcast date (YYYY-MM-DD). Defaults to most recent Wed."
+        required: true
+        default: $(date -d'last wednesday' +%Y-%m-%d)
 
 permissions:
     contents: write
     pull-requests: write
 
 jobs:
+
+  # Create target data for the round that closed 90 days ago.
+  # This step will exit if there is no round with a nowcast
+  # date 90 days ago.
+  create-target-data:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+        with:
+            # only checkout what we need
+            sparse-checkout: |
+              .github/
+              auxiliary-data/
+              hub-config/
+              target-data/
+              src/
+
+      - name: Install uv 🐍
+        uses: astral-sh/setup-uv@v2
+        with:
+          version: "0.4.9"
+          enable-cache: true
+
+      - name: Get nowcast date (aka round_id) 🕰️
+        # if nowcast_date is not provided, use the most recent Wednesday
+        run: |
+          if [ -z "${{ inputs.nowcast_date }}" ]; then
+            NOWCAST_DATE=$(date -d'last wednesday' +%Y-%m-%d)
+          else
+            NOWCAST_DATE=${{ inputs.nowcast_date }}
+          fi
+          echo "NOWCAST_DATE=$NOWCAST_DATE" >> $GITHUB_ENV
+          echo "Getting nowcast date for most recent round: $NOWCAST_DATE"
+
+      #uv run get_target_data.py --nowcast-date=$NOWCAST_DATE
+      - name: Create target data 🎯
+        run: |
+          mkdir -p target-data
+          echo "This is a test" > target-data/testy.txt
+
+      - name: Create PR for new target data
+        uses: ./.github/actions/create-pr
+        with:
+          pr-prefix: "${{ env.NOWCAST_DATE }}_target_data"
+          file-path: target-data/
+          commit-message: "Add target data for round $NOWCAST_DATE"
+          pr-body: "Created via GitHub Actions: generate target data for round $NOWCAST_DATE"
+
+
   create-location-date-sequence-counts:
     runs-on: ubuntu-latest
     steps:
@@ -31,27 +89,33 @@ jobs:
           version: "0.4.9"
           enable-cache: true
 
-      - name: Create file of sequence counts by location and date 🦠
-        run: |
-          uv run get_location_date_counts.py
-        working-directory: src
-
-      - name: Get current date and time 🕰️
+      - name: Test step
         run: |
           PR_DATETIME=$(date +'%Y-%m-%d_%H-%M-%S')
           echo "PR_DATETIME=$PR_DATETIME" >> $GITHUB_ENV
+          echo "PR_DATETIME=$PR_DATETIME"
 
-      - name: Create PR for sequence counts 🚀
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -b new_location_date_sequence_counts_"$PR_DATETIME"
-          git add auxiliary-data/unscored-location-dates/
-          git commit -m "Add sequence counts by location & date $PR_DATETIME"
-          git push -u origin new_location_date_sequence_counts_"$PR_DATETIME"
-          gh pr create \
-            --base main \
-            --title "Add new sequence counts by location and date $PR_DATETIME" \
-            --body "Created via GitHub Actions: generate count of sequences collected by date/location for the past 31 days."
+      # - name: Create file of sequence counts by location and date 🦠
+      #   run: |
+      #     uv run get_location_date_counts.py
+      #   working-directory: src
+
+      # - name: Get current date and time 🕰️
+      #   run: |
+      #     PR_DATETIME=$(date +'%Y-%m-%d_%H-%M-%S')
+      #     echo "PR_DATETIME=$PR_DATETIME" >> $GITHUB_ENV
+
+      # - name: Create PR for sequence counts 🚀
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: |
+      #     git config user.name "github-actions[bot]"
+      #     git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      #     git checkout -b new_location_date_sequence_counts_"$PR_DATETIME"
+      #     git add auxiliary-data/unscored-location-dates/
+      #     git commit -m "Add sequence counts by location & date $PR_DATETIME"
+      #     git push -u origin new_location_date_sequence_counts_"$PR_DATETIME"
+      #     gh pr create \
+      #       --base main \
+      #       --title "Add new sequence counts by location and date $PR_DATETIME" \
+      #       --body "Created via GitHub Actions: generate count of sequences collected by date/location for the past 31 days."

--- a/.github/workflows/create-location-date-sequence-counts.yaml
+++ b/.github/workflows/create-location-date-sequence-counts.yaml
@@ -38,10 +38,9 @@ jobs:
               src/
 
       - name: Install uv 🐍
-        uses: astral-sh/setup-uv@v2
+        uses: astral-sh/setup-uv@v5
         with:
-          version: "0.4.9"
-          enable-cache: true
+          version: ">=0.0.1"
 
       - name: Get nowcast date (aka round_id) 🕰️
         # if nowcast_date is not provided, use the most recent Wednesday
@@ -84,10 +83,9 @@ jobs:
               src/
 
       - name: Install uv 🐍
-        uses: astral-sh/setup-uv@v2
+        uses: astral-sh/setup-uv@v5
         with:
-          version: "0.4.9"
-          enable-cache: true
+          version: ">=0.0.1"
 
       - name: Test step
         run: |

--- a/.github/workflows/create-location-date-sequence-counts.yaml
+++ b/.github/workflows/create-location-date-sequence-counts.yaml
@@ -11,14 +11,8 @@ on:
   workflow_dispatch:
     inputs:
       nowcast_date:
-        description: "Nowcast date (YYYY-MM-DD). Defaults to most recent Wed."
-        required: true
-        default: |
-          $(if [ $(date +%u) -eq 3 ]; then
-            date +%Y-%m-%d
-          else
-            date -d'last wednesday' +%Y-%m-%d
-          fi)
+        description: "Nowcast date (YYYY-MM-DD)"
+        required: false
 
 permissions:
     contents: write
@@ -52,12 +46,9 @@ jobs:
       - name: Get nowcast date (aka round_id) 🕰️
         # if nowcast_date is not provided, use the most recent Wednesday
         run: |
+          source ${GITHUB_WORKSPACE}/.github/shared/shared-functions.sh
           if [ -z "${{ inputs.nowcast_date }}" ]; then
-            NOWCAST_DATE=$(if [ $(date +%u) -eq 3 ]; then
-              date +%Y-%m-%d
-            else
-              date -d'last wednesday' +%Y-%m-%d
-            fi)
+            NOWCAST_DATE=$(get_latest_wednesday)
           else
             NOWCAST_DATE=${{ inputs.nowcast_date }}
           fi

--- a/.github/workflows/create-location-date-sequence-counts.yaml
+++ b/.github/workflows/create-location-date-sequence-counts.yaml
@@ -1,7 +1,7 @@
 # This workflow is designed to run shortly after the hub's weekly submission
 # deadline. It generates an unscored-location-dates file as well as time
 # series and oracle output target data.
-name: Run post-submission close jobs
+name: Run post-submission jobs
 
 on:
   schedule:
@@ -13,7 +13,12 @@ on:
       nowcast_date:
         description: "Nowcast date (YYYY-MM-DD). Defaults to most recent Wed."
         required: true
-        default: $(date -d'last wednesday' +%Y-%m-%d)
+        default: |
+          $(if [ $(date +%u) -eq 3 ]; then
+            date +%Y-%m-%d
+          else
+            date -d'last wednesday' +%Y-%m-%d
+          fi)
 
 permissions:
     contents: write
@@ -48,7 +53,11 @@ jobs:
         # if nowcast_date is not provided, use the most recent Wednesday
         run: |
           if [ -z "${{ inputs.nowcast_date }}" ]; then
-            NOWCAST_DATE=$(date -d'last wednesday' +%Y-%m-%d)
+            NOWCAST_DATE=$(if [ $(date +%u) -eq 3 ]; then
+              date +%Y-%m-%d
+            else
+              date -d'last wednesday' +%Y-%m-%d
+            fi)
           else
             NOWCAST_DATE=${{ inputs.nowcast_date }}
           fi

--- a/.github/workflows/create-location-date-sequence-counts.yaml
+++ b/.github/workflows/create-location-date-sequence-counts.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Create target data 🎯
         run: |
           export CLADETIME_DEMO=true
-          uv run get_target_data.py --nowcast-date=$NOWCAST_DATE
+          uv run src/get_target_data.py --nowcast-date=$NOWCAST_DATE
 
       - name: Create PR for new target data
         uses: ./.github/actions/create-pr
@@ -93,8 +93,7 @@ jobs:
 
       - name: Create file of sequence counts by location and date 🦠
         run: |
-          uv run get_location_date_counts.py
-        working-directory: src
+          uv run src/get_location_date_counts.py
 
       - name: Create PR for sequence counts 🚀
         uses: ./.github/actions/create-pr

--- a/.github/workflows/create-location-date-sequence-counts.yaml
+++ b/.github/workflows/create-location-date-sequence-counts.yaml
@@ -42,27 +42,30 @@ jobs:
         with:
           version: ">=0.0.1"
 
-      - name: Get nowcast date (aka round_id) 🕰️
+      - name: Get nowcast date (aka round_id) for target data🕰️
         # if nowcast_date is not provided, use the most recent Wednesday
         run: |
           source ${GITHUB_WORKSPACE}/.github/shared/shared-functions.sh
           NOWCAST_DATE=$(get_latest_wednesday "${{ inputs.nowcast_date }}")
+          TARGET_NOWCAST_DATE=$(date -d "$NOWCAST_DATE - 91 days" +%Y-%m-%d)
           echo "NOWCAST_DATE=$NOWCAST_DATE" >> $GITHUB_ENV
-          echo "Nowcast date for most recent round: $NOWCAST_DATE"
+          echo "TARGET_NOWCAST_DATE=$TARGET_NOWCAST_DATE" >> $GITHUB_ENV
+          echo "Creating target data for round $TARGET_NOWCAST_DATE"
 
       # remove CLADETIME_DEMO=true when done testing
       - name: Create target data 🎯
         run: |
           export CLADETIME_DEMO=true
-          uv run src/get_target_data.py --nowcast-date=$NOWCAST_DATE
+          uv run get_target_data.py --nowcast-date=$TARGET_NOWCAST_DATE
+        working-directory: src
 
       - name: Create PR for new target data
         uses: ./.github/actions/create-pr
         with:
-          pr-prefix: "${{ env.NOWCAST_DATE }} target data"
+          pr-prefix: "${{ env.TARGET_NOWCAST_DATE }} target data"
           file-path: target-data/
-          commit-message: "Add target data for round $NOWCAST_DATE"
-          pr-body: "Created via GitHub Actions: generate target data for round $NOWCAST_DATE"
+          commit-message: "Add target data for round $TARGET_NOWCAST_DATE"
+          pr-body: "Created via GitHub Actions: generate target data for round $TARGET_NOWCAST_DATE"
 
 
   create-location-date-sequence-counts:
@@ -93,7 +96,8 @@ jobs:
 
       - name: Create file of sequence counts by location and date 🦠
         run: |
-          uv run src/get_location_date_counts.py
+          uv run get_location_date_counts.py
+        working-directory: src
 
       - name: Create PR for sequence counts 🚀
         uses: ./.github/actions/create-pr

--- a/.github/workflows/create-location-date-sequence-counts.yaml
+++ b/.github/workflows/create-location-date-sequence-counts.yaml
@@ -50,16 +50,16 @@ jobs:
           echo "NOWCAST_DATE=$NOWCAST_DATE" >> $GITHUB_ENV
           echo "Nowcast date for most recent round: $NOWCAST_DATE"
 
-      #uv run get_target_data.py --nowcast-date=$NOWCAST_DATE
+      # remove CLADETIME_DEMO=true when done testing
       - name: Create target data 🎯
         run: |
-          mkdir -p target-data
-          echo "This is a test" > target-data/testy.txt
+          export CLADETIME_DEMO=true
+          uv run get_target_data.py --nowcast-date=$NOWCAST_DATE
 
       - name: Create PR for new target data
         uses: ./.github/actions/create-pr
         with:
-          pr-prefix: "${{ env.NOWCAST_DATE }}_target_data"
+          pr-prefix: "${{ env.NOWCAST_DATE }} target data"
           file-path: target-data/
           commit-message: "Add target data for round $NOWCAST_DATE"
           pr-body: "Created via GitHub Actions: generate target data for round $NOWCAST_DATE"
@@ -71,8 +71,7 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v4
         with:
-            # don't check out repo folders with large amounts of data
-            # (e.g., model-output, target-data)
+            # only checkout what we need
             sparse-checkout: |
               .github/
               auxiliary-data/
@@ -92,27 +91,15 @@ jobs:
           echo "NOWCAST_DATE=$NOWCAST_DATE" >> $GITHUB_ENV
           echo "Nowcast date for most recent round: $NOWCAST_DATE"
 
-      # - name: Create file of sequence counts by location and date 🦠
-      #   run: |
-      #     uv run get_location_date_counts.py
-      #   working-directory: src
+      - name: Create file of sequence counts by location and date 🦠
+        run: |
+          uv run get_location_date_counts.py
+        working-directory: src
 
-      # - name: Get current date and time 🕰️
-      #   run: |
-      #     PR_DATETIME=$(date +'%Y-%m-%d_%H-%M-%S')
-      #     echo "PR_DATETIME=$PR_DATETIME" >> $GITHUB_ENV
-
-      # - name: Create PR for sequence counts 🚀
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: |
-      #     git config user.name "github-actions[bot]"
-      #     git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-      #     git checkout -b new_location_date_sequence_counts_"$PR_DATETIME"
-      #     git add auxiliary-data/unscored-location-dates/
-      #     git commit -m "Add sequence counts by location & date $PR_DATETIME"
-      #     git push -u origin new_location_date_sequence_counts_"$PR_DATETIME"
-      #     gh pr create \
-      #       --base main \
-      #       --title "Add new sequence counts by location and date $PR_DATETIME" \
-      #       --body "Created via GitHub Actions: generate count of sequences collected by date/location for the past 31 days."
+      - name: Create PR for sequence counts 🚀
+        uses: ./.github/actions/create-pr
+        with:
+          pr-prefix: "${{ env.NOWCAST_DATE }} unscored locations"
+          file-path: auxiliary-data/unscored-location-dates/
+          commit-message: "Add unscored locations for round $NOWCAST_DATE"
+          pr-body: "Created via GitHub Actions: generate count of sequences collected by date/location for the past 31 days."

--- a/.github/workflows/create-location-date-sequence-counts.yaml
+++ b/.github/workflows/create-location-date-sequence-counts.yaml
@@ -46,13 +46,9 @@ jobs:
         # if nowcast_date is not provided, use the most recent Wednesday
         run: |
           source ${GITHUB_WORKSPACE}/.github/shared/shared-functions.sh
-          if [ -z "${{ inputs.nowcast_date }}" ]; then
-            NOWCAST_DATE=$(get_latest_wednesday)
-          else
-            NOWCAST_DATE=${{ inputs.nowcast_date }}
-          fi
+          NOWCAST_DATE=$(get_latest_wednesday "${{ inputs.nowcast_date }}")
           echo "NOWCAST_DATE=$NOWCAST_DATE" >> $GITHUB_ENV
-          echo "Getting nowcast date for most recent round: $NOWCAST_DATE"
+          echo "Nowcast date for most recent round: $NOWCAST_DATE"
 
       #uv run get_target_data.py --nowcast-date=$NOWCAST_DATE
       - name: Create target data 🎯
@@ -78,6 +74,7 @@ jobs:
             # don't check out repo folders with large amounts of data
             # (e.g., model-output, target-data)
             sparse-checkout: |
+              .github/
               auxiliary-data/
               hub-config/
               src/
@@ -87,11 +84,13 @@ jobs:
         with:
           version: ">=0.0.1"
 
-      - name: Test step
+      - name: Get nowcast date (aka round_id) 🕰️
+        # if nowcast_date is not provided, use the most recent Wednesday
         run: |
-          PR_DATETIME=$(date +'%Y-%m-%d_%H-%M-%S')
-          echo "PR_DATETIME=$PR_DATETIME" >> $GITHUB_ENV
-          echo "PR_DATETIME=$PR_DATETIME"
+          source ${GITHUB_WORKSPACE}/.github/shared/shared-functions.sh
+          NOWCAST_DATE=$(get_latest_wednesday "${{ inputs.nowcast_date }}")
+          echo "NOWCAST_DATE=$NOWCAST_DATE" >> $GITHUB_ENV
+          echo "Nowcast date for most recent round: $NOWCAST_DATE"
 
       # - name: Create file of sequence counts by location and date 🦠
       #   run: |

--- a/.github/workflows/create-location-date-sequence-counts.yaml
+++ b/.github/workflows/create-location-date-sequence-counts.yaml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Create file of sequence counts by location and date 🦠
         run: |
-          uv run get_location_date_counts.py
+          uv run get_location_date_counts.py --nowcast-date=$NOWCAST_DATE
         working-directory: src
 
       - name: Create PR for sequence counts 🚀

--- a/.github/workflows/create-location-date-sequence-counts.yaml
+++ b/.github/workflows/create-location-date-sequence-counts.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Create PR for new target data
         uses: ./.github/actions/create-pr
         with:
-          pr-prefix: "${{ env.TARGET_NOWCAST_DATE }} target data"
+          pr-prefix: "${{ env.TARGET_NOWCAST_DATE }}-target-data"
           file-path: target-data/
           commit-message: "Add target data for round $TARGET_NOWCAST_DATE"
           pr-body: "Created via GitHub Actions: generate target data for round $TARGET_NOWCAST_DATE"
@@ -102,7 +102,7 @@ jobs:
       - name: Create PR for sequence counts 🚀
         uses: ./.github/actions/create-pr
         with:
-          pr-prefix: "${{ env.NOWCAST_DATE }} unscored locations"
+          pr-prefix: "${{ env.NOWCAST_DATE }}-unscored-locations"
           file-path: auxiliary-data/unscored-location-dates/
           commit-message: "Add unscored locations for round $NOWCAST_DATE"
           pr-body: "Created via GitHub Actions: generate count of sequences collected by date/location for the past 31 days."

--- a/.github/workflows/run-post-submission-jobs.yaml
+++ b/.github/workflows/run-post-submission-jobs.yaml
@@ -52,10 +52,8 @@ jobs:
           echo "TARGET_NOWCAST_DATE=$TARGET_NOWCAST_DATE" >> $GITHUB_ENV
           echo "Creating target data for round $TARGET_NOWCAST_DATE"
 
-      # remove CLADETIME_DEMO=true when done testing
       - name: Create target data 🎯
         run: |
-          export CLADETIME_DEMO=true
           uv run get_target_data.py --nowcast-date=$TARGET_NOWCAST_DATE
         working-directory: src
 

--- a/src/get_target_data.py
+++ b/src/get_target_data.py
@@ -19,7 +19,7 @@ uv run --with-requirements src/requirements.txt --module pytest src/get_target_d
 """
 
 # /// script
-# requires-python = "==3.12"
+# requires-python = ">=3.12,<3.13"
 # dependencies = [
 #   "click",
 #   "cladetime@git+https://github.com/reichlab/cladetime",
@@ -207,7 +207,10 @@ def main(
     # Nowcast_date must match a variant-nowcast-hub round_id
     nowcast_string = nowcast_date.strftime("%Y-%m-%d")
     modeled_clades_path = (
-        Path("auxiliary-data/modeled-clades") / f"{nowcast_string}.json"
+        Path(__file__).parents[1]
+        / "auxiliary-data"
+        / "modeled-clades"
+        / f"{nowcast_string}.json"
     )
     if not modeled_clades_path.is_file():
         logger.info(

--- a/src/get_target_data.py
+++ b/src/get_target_data.py
@@ -216,7 +216,7 @@ def main(
         logger.info(
             f"Stopping script. No round found for nowcast_date: {nowcast_string}"
         )
-        sys.exit(1)
+        sys.exit(0)
     else:
         modeled_clades = json.loads(modeled_clades_path.read_text(encoding="utf-8"))
         clade_list = modeled_clades.get("clades", [])
@@ -421,8 +421,9 @@ def test_set_option_defaults():
     assert result == datetime(2024, 10, 12, 23, 59, 59, tzinfo=timezone.utc)
 
 
-def test_bad_inputs():
+def test_bad_inputs(caplog):
     """Bad inputs should return a non-zero exit code."""
+    caplog.set_level(logging.INFO)
     runner = CliRunner()
 
     # sequence_as_of cannot be in the future
@@ -455,7 +456,8 @@ def test_bad_inputs():
             color=True,
             standalone_mode=False,
         )
-        assert result.exit_code == 1
+        assert result.exit_code == 0
+        assert "stopping script" in caplog.text.lower()
 
 
 def test_target_data():

--- a/src/get_target_data.py
+++ b/src/get_target_data.py
@@ -422,7 +422,7 @@ def test_set_option_defaults():
 
 
 def test_bad_inputs(caplog):
-    """Bad inputs should return a non-zero exit code."""
+    """Bad inputs should return a non-zero exit code or a graceful script exit."""
     caplog.set_level(logging.INFO)
     runner = CliRunner()
 

--- a/target-data/README.md
+++ b/target-data/README.md
@@ -1,0 +1,1 @@
+# Target Data


### PR DESCRIPTION
**Ready for review. PR is in draft status so we don't merge before the break.**

Resolves #216 

This PR adds a second job to the post-submission deadline workflow that runs on Wednesday nights. There are a few other changes to the workflow

- Make the previous "get location and date counts" job date aware, so we can run the step using prior round_ids instead of using the current date
- Move the PR submission logic into a re-usable composite action
- Create a shared function for determining the most recent nowcast_date (if one isn't passed in via the workflow_dispatch trigger)
- Bump uv version to pick up some caching goodies

In addition, the .py scripts themselves required a few tweaks to make this all work.

Would not recommend reviewing commit by commit--there was a lot of thrashing around.

