### PR TITLE
Implement a matrix strategy for generating target data

### DIFF
--- a/.github/shared/shared-functions.sh
+++ b/.github/shared/shared-functions.sh
@@ -26,18 +26,9 @@ generate_weekly_dates() {
     local weeks=$2
     local current_date=$start_date
 
-    # Format for GitHub Actions matrix
-    echo -n '{"include":['
-
-    for ((i=1; i<=$weeks; i++)); do
-        current_date=$(date -d "$current_date - 7 days" +%Y-%m-%d)
-        if [ $i -eq $weeks ]; then
-            # last item does not get a trailing comma
-            echo -n "{\"nowcast-date\":\"$current_date\"}"
-        else
-            echo -n "{\"nowcast-date\":\"$current_date\"},"
-        fi
-    done
-
-    echo ']}'
+    # Format a series of dates for GitHub Actions matrix
+    seq 0 7 $(bc --expression="7 * $weeks") \
+    | xargs -I {} date -d "$start_date -{} days" +%Y-%m-%d \
+    | jq -R \
+    | jq -s '. | map({"nowcast-date": .}) | {"include": .}'
 }

--- a/.github/shared/shared-functions.sh
+++ b/.github/shared/shared-functions.sh
@@ -30,5 +30,5 @@ generate_weekly_dates() {
     seq 0 7 $(echo "7 * $weeks" | bc) \
     | xargs -I {} date -d "$start_date -{} days" +%Y-%m-%d \
     | jq -R \
-    | jq -s '. | map({"nowcast-date": .}) | {"include": .}'
+    | jq -sc '. | map({"nowcast-date": .}) | {"include": .}'
 }

--- a/.github/shared/shared-functions.sh
+++ b/.github/shared/shared-functions.sh
@@ -1,5 +1,7 @@
 # shared bash functions to use in workflows
 
+# Get the most recent Wednesday. Used to determine the most recent nowcast_date
+# for the variant-nowcast-hub.
 get_latest_wednesday() {
     local input_date="$1"
     if [ -n "$input_date" ]; then
@@ -11,4 +13,30 @@ get_latest_wednesday() {
             date -d'last wednesday' +%Y-%m-%d
         fi
     fi
+}
+
+# Create a series of dates formatted to work with a GitHub actions matrix
+generate_weekly_dates() {
+    if [ $# -ne 2 ]; then
+        echo "Usage: generate_weekly_dates YYYY-MM-DD number_of_weeks" >&2
+        return 1
+    fi
+
+    local start_date=$1
+    local weeks=$2
+    local current_date=$start_date
+
+    # Format for GitHub Actions matrix
+    echo -n '{"include":['
+
+    for ((i=1; i<=$weeks; i++)); do
+        current_date=$(date -d "$current_date - 7 days" +%Y-%m-%d)
+        if [ $i -eq $weeks ]; then
+            echo -n "{\"nowcast-date\":\"$current_date\"}"
+        else
+            echo -n "{\"nowcast-date\":\"$current_date\"},"
+        fi
+    done
+
+    echo ']}'
 }

--- a/.github/shared/shared-functions.sh
+++ b/.github/shared/shared-functions.sh
@@ -27,7 +27,7 @@ generate_weekly_dates() {
     local current_date=$start_date
 
     # Format a series of dates for GitHub Actions matrix
-    seq 0 7 $(bc --expression="7 * $weeks") \
+    seq 0 7 $(echo "7 * $weeks" | bc) \
     | xargs -I {} date -d "$start_date -{} days" +%Y-%m-%d \
     | jq -R \
     | jq -s '. | map({"nowcast-date": .}) | {"include": .}'

--- a/.github/shared/shared-functions.sh
+++ b/.github/shared/shared-functions.sh
@@ -32,6 +32,7 @@ generate_weekly_dates() {
     for ((i=1; i<=$weeks; i++)); do
         current_date=$(date -d "$current_date - 7 days" +%Y-%m-%d)
         if [ $i -eq $weeks ]; then
+            # last item does not get a trailing comma
             echo -n "{\"nowcast-date\":\"$current_date\"}"
         else
             echo -n "{\"nowcast-date\":\"$current_date\"},"

--- a/.github/workflows/run-post-submission-jobs.yaml
+++ b/.github/workflows/run-post-submission-jobs.yaml
@@ -20,11 +20,50 @@ permissions:
 
 jobs:
 
+  get-all-dates:
+    runs-on: ubuntu-latest
+    outputs:
+      NOWCAST_DATE: ${{ steps.set-dates.outputs.NOWCAST_DATE }}
+      SEQUENCE_AS_OF: ${{ steps.set-dates.outputs.SEQUENCE_AS_OF }}
+      matrix: ${{ steps.set-dates.outputs.MATRIX_DATES }}
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+        with:
+            # only checkout what we need
+            sparse-checkout: |
+              .github/
+
+      - name: Set dates 🕰️
+        id: set-dates
+        # Nowcast_date = round_id of the round that just closed for submissions.
+        # Sequence_as_of = date used to get the sequences for clade assignment.
+        # Matrix_dates = dates used for matrix in create-target-data job (including
+        # the round_id of the 91-day-old round that can now be officially closed).
+        run: |
+          source ${GITHUB_WORKSPACE}/.github/shared/shared-functions.sh
+          nowcast_date=$(get_latest_wednesday "${{ inputs.nowcast_date }}")
+          sequence_as_of=$(date -d "$nowcast_date - 1 day" +%Y-%m-%d)
+          matrix_dates=$(generate_weekly_dates "$nowcast_date" 13)
+          echo "nowcast_date=$nowcast_date" >> $GITHUB_OUTPUT
+          echo "sequence_as_of=$sequence_as_of" >> $GITHUB_OUTPUT
+          echo "matrix_dates=$matrix_dates" >> $GITHUB_OUTPUT
+
+          echo -e "\nDebug values:"
+          echo "Nowcast date: $nowcast_date"
+          echo "Sequence as of: $sequence_as_of"
+          echo "Matrix dates: $matrix_dates"
+
   # Create target data for the round that closed 90 days ago.
   # This step will exit if there is no round with a nowcast
   # date 90 days ago.
   create-target-data:
     runs-on: ubuntu-latest
+    needs: get-all-dates
+    env:
+      SEQUENCE_AS_OF: ${{ needs.get-all-dates.outputs.sequence_as_of }}
+    strategy:
+      matrix: ${{ fromJson(needs.get-all-dates.outputs.matrix) }}
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v4
@@ -42,32 +81,67 @@ jobs:
         with:
           version: ">=0.0.1"
 
-      - name: Get nowcast date (aka round_id) for target data🕰️
-        # if nowcast_date is not provided, use the most recent Wednesday
-        run: |
-          source ${GITHUB_WORKSPACE}/.github/shared/shared-functions.sh
-          NOWCAST_DATE=$(get_latest_wednesday "${{ inputs.nowcast_date }}")
-          TARGET_NOWCAST_DATE=$(date -d "$NOWCAST_DATE - 91 days" +%Y-%m-%d)
-          echo "NOWCAST_DATE=$NOWCAST_DATE" >> $GITHUB_ENV
-          echo "TARGET_NOWCAST_DATE=$TARGET_NOWCAST_DATE" >> $GITHUB_ENV
-          echo "Creating target data for round $TARGET_NOWCAST_DATE"
-
       - name: Create target data 🎯
         run: |
-          uv run get_target_data.py --nowcast-date=$TARGET_NOWCAST_DATE
+          echo "sequence_as_of: $SEQUENCE_AS_OF"
+          uv run get_target_data.py \
+          --nowcast-date=${{ matrix.nowcast-date }} \
+          --sequence-as-of=$SEQUENCE_AS_OF \
+          --target-data-dir=${{ github.workspace }}
         working-directory: src
 
-      - name: Create PR for new target data
+      - name: Upload target data 📤
+        uses: actions/upload-artifact@v4
+        with:
+          name: target-data-${{ matrix.nowcast-date }}
+          path: |
+            ${{ github.workspace }}/time-series/**/**/*.parquet
+            ${{ github.workspace }}/oracle-output/**/*.parquet
+
+  target-data-pr:
+    runs-on: ubuntu-latest
+    needs: create-target-data
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+        with:
+            # only checkout what we need
+            sparse-checkout: |
+              .github/
+              auxiliary-data/
+              hub-config/
+              target-data/
+              src/
+
+      - name: Download target data 📥
+        uses: actions/download-artifact@v4
+        with:
+          pattern: target-data-*
+          merge-multiple: true
+          path: ${{ github.workspace }}
+
+      - name: Move target and interim data to hub directory ➡️
+        run: |
+          echo "Merging new target data files into target-data directory"
+          cp -R ${{ github.workspace }}/time-series/* ${{ github.workspace }}/target-data/time-series/
+          cp -R ${{ github.workspace }}/oracle-output/* ${{ github.workspace }}/target-data/oracle-output/
+          echo "Contents of target-data after merge:"
+          ls -lR ${{ github.workspace }}/target-data/
+
+      - name: Create PR for new target and interim data
         uses: ./.github/actions/create-pr
         with:
-          pr-prefix: "${{ env.TARGET_NOWCAST_DATE }}-target-data"
+          pr-prefix: "add-target-data"
           file-path: target-data/
-          commit-message: "Add target data for round $TARGET_NOWCAST_DATE"
-          pr-body: "Created via GitHub Actions: generate target data for round $TARGET_NOWCAST_DATE"
-
+          commit-message: "Add target data and interim files."
+          pr-body: "Created via GitHub Actions: generate target and interim data."
 
   create-location-date-sequence-counts:
     runs-on: ubuntu-latest
+    needs: get-all-dates
+    env:
+      NOWCAST_DATE: ${{ needs.get-all-dates.outputs.nowcast_date }}
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v4
@@ -83,14 +157,6 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           version: ">=0.0.1"
-
-      - name: Get nowcast date (aka round_id) 🕰️
-        # if nowcast_date is not provided, use the most recent Wednesday
-        run: |
-          source ${GITHUB_WORKSPACE}/.github/shared/shared-functions.sh
-          NOWCAST_DATE=$(get_latest_wednesday "${{ inputs.nowcast_date }}")
-          echo "NOWCAST_DATE=$NOWCAST_DATE" >> $GITHUB_ENV
-          echo "Nowcast date for most recent round: $NOWCAST_DATE"
 
       - name: Create file of sequence counts by location and date 🦠
         run: |

--- a/src/get_target_data.py
+++ b/src/get_target_data.py
@@ -135,6 +135,17 @@ def set_collection_max_date(ctx, param, value):
     value = value.replace(hour=23, minute=59, second=59, tzinfo=timezone.utc)
     return value
 
+def set_target_data_dir(ctx, param, value):
+    """Set the target_data_dir default value to the hub's target-data directory."""
+    if value is None:
+        value = Path(__file__).parents[1] / "target-data"
+    elif value == ".":
+        value = Path.cwd()
+    else:
+        value = Path(value)
+
+    return value
+
 
 @click.command()
 @click.option(
@@ -177,10 +188,14 @@ def set_collection_max_date(ctx, param, value):
 )
 @click.option(
     "--target-data-dir",
-    type=Path,
+    type=str,
     required=False,
-    default=Path(__file__).parents[1] / "target-data",
-    help="For testing only: Path object to the directory where the target data will be saved. Default is the hub's target-data directory.",
+    default=None,
+    callback=set_target_data_dir,
+    help=(
+        "Path object to the directory where the target data will be saved. Default is the hub's target-data directory. "
+        "Specify '.' to save target data to the current working directory."
+    )
 )
 def main(
     nowcast_date: datetime,
@@ -589,7 +604,7 @@ def test_target_data_integration(caplog, tmp_path):
             "--nowcast-date",
             nowcast_date,
             "--target-data-dir",
-            tmp_path,
+            str(tmp_path),
         ],
         color=True,
         catch_exceptions=False,


### PR DESCRIPTION
Closes #276 

**Overview**

Now that we want to generate multiple versions of the time-series and oracle-output target data files, this changeset adds three major changes to the run-post-submissions-jobs workflow that runs after round submissions close:

1. A new bash function that uses the nowcast_date of the most recent round to create a matrix of nowcast_dates going back 13 weeks
2. Use the above output to add a matrix strategy to the create-target-data job (i.e., run the job once for each week of target/interim data we're creating)
3. Upload the generated target data files as artifacts, which are then combined and submitted as a PR in the target-data-pr job.

**Testing**

- A complete test run of these changes: https://github.com/reichlab/variant-nowcast-hub/actions/runs/12931484389
- The target data PR generated by the above test run (ignore anything not in `target-data/`): https://github.com/reichlab/variant-nowcast-hub/pull/287/files
- To access the new target-data files locally, check out the `add-target-data_2025-01-23_14-53-19` branch of this repo

**Other info**

- Total run time of the updated `post-submission-jobs` workflow per the run details `usage` field is 2 hr 51 in (I assume this is compute time; ~~free GitHub accounts get [2,000 free minutes per month](https://docs.github.com/en/billing/managing-billing-for-your-products/managing-billing-for-github-actions/about-billing-for-github-actions#included-storage-and-minutes))~~ <- @zkamvar corrected me on this: the limit is only for private repos
- Total wall time for the updated workflow is 17 minutes

Contents of my local `target-data` directory after checking out `add-target-data_2025-01-23_14-53-19`:

```
├── README.md
├── oracle-output
│   ├── nowcast_date=2024-10-09
│   │   └── oracle.parquet
│   ├── nowcast_date=2024-10-16
│   │   └── oracle.parquet
│   ├── nowcast_date=2024-10-23
│   │   └── oracle.parquet
│   ├── nowcast_date=2024-10-30
│   │   └── oracle.parquet
│   ├── nowcast_date=2024-11-06
│   │   └── oracle.parquet
│   ├── nowcast_date=2024-11-13
│   │   └── oracle.parquet
│   ├── nowcast_date=2024-11-20
│   │   └── oracle.parquet
│   ├── nowcast_date=2024-11-27
│   │   └── oracle.parquet
│   ├── nowcast_date=2024-12-04
│   │   └── oracle.parquet
│   ├── nowcast_date=2024-12-11
│   │   └── oracle.parquet
│   ├── nowcast_date=2024-12-18
│   │   └── oracle.parquet
│   ├── nowcast_date=2024-12-25
│   │   └── oracle.parquet
│   ├── nowcast_date=2025-01-01
│   │   └── oracle.parquet
│   ├── nowcast_date=2025-01-08
│   │   └── oracle.parquet
│   └── nowcast_date=2025-01-15
│       └── oracle.parquet
└── time-series
    ├── nowcast_date=2024-10-09
    │   └── sequence_as_of=2025-01-07
    │       └── timeseries.parquet
    ├── nowcast_date=2024-10-16
    │   └── sequence_as_of=2025-01-14
    │       └── timeseries.parquet
    ├── nowcast_date=2024-10-23
    │   └── sequence_as_of=2025-01-21
    │       └── timeseries.parquet
    ├── nowcast_date=2024-10-30
    │   └── sequence_as_of=2025-01-21
    │       └── timeseries.parquet
    ├── nowcast_date=2024-11-06
    │   └── sequence_as_of=2025-01-21
    │       └── timeseries.parquet
    ├── nowcast_date=2024-11-13
    │   └── sequence_as_of=2025-01-21
    │       └── timeseries.parquet
    ├── nowcast_date=2024-11-20
    │   └── sequence_as_of=2025-01-21
    │       └── timeseries.parquet
    ├── nowcast_date=2024-11-27
    │   └── sequence_as_of=2025-01-21
    │       └── timeseries.parquet
    ├── nowcast_date=2024-12-04
    │   └── sequence_as_of=2025-01-21
    │       └── timeseries.parquet
    ├── nowcast_date=2024-12-11
    │   └── sequence_as_of=2025-01-21
    │       └── timeseries.parquet
    ├── nowcast_date=2024-12-18
    │   └── sequence_as_of=2025-01-21
    │       └── timeseries.parquet
    ├── nowcast_date=2024-12-25
    │   └── sequence_as_of=2025-01-21
    │       └── timeseries.parquet
    ├── nowcast_date=2025-01-01
    │   └── sequence_as_of=2025-01-21
    │       └── timeseries.parquet
    ├── nowcast_date=2025-01-08
    │   └── sequence_as_of=2025-01-21
    │       └── timeseries.parquet
    └── nowcast_date=2025-01-15
        └── sequence_as_of=2025-01-21
            └── timeseries.parquet
```

This is what the updated workflow looks like as it runs (a cute little mini DAG):

![image](https://github.com/user-attachments/assets/9a8cded1-d89b-415e-a16f-72cecfb63f1a)
