### PR TITLE
add token to R steps

### DIFF
--- a/.github/workflows/create-modeling-round.yaml
+++ b/.github/workflows/create-modeling-round.yaml
@@ -37,11 +37,15 @@ jobs:
           extra-repositories: 'https://hubverse-org.r-universe.dev'
 
       - name: Set up renv 📦
+        env:
+          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
         uses: r-lib/actions/setup-renv@v2
         with:
           working-directory: src
 
       - name: Create clade list and update tasks.json 🦠
+        env:
+          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
         run: |
           uv run get_clades_to_model.py
           Rscript make_round_config.R


### PR DESCRIPTION
This adds a GitHub token to the R steps for creating new modelling rounds.

[a previous run for create new modelling rounds failed](https://github.com/reichlab/variant-nowcast-hub/actions/runs/12981274062/job/36199482676) because the GitHub API limit was exceeded for the following reasons:

- the renv setup uses github API calls to fetch packages
- the version of hubUtils we have uses API calls to fetch the schema, even though they are cached.
- neither of the steps for these API calls had the GitHub token available as an enviroment variable, as indicated by
  the [warning from renv about using `GITHUB_PAT`](https://github.com/reichlab/variant-nowcast-hub/actions/runs/12981274062/job/36199482676#step:5:255):


```
- GitHub authentication credentials are not available.
- Please set GITHUB_PAT, or ensure the 'gitcreds' package is installed.
- See https://usethis.r-lib.org/articles/git-credentials.html for more details.
```


