### PR TITLE
create target-data subfolders if they don't already exist

### DIFF
--- a/.github/workflows/run-post-submission-jobs.yaml
+++ b/.github/workflows/run-post-submission-jobs.yaml
@@ -124,7 +124,9 @@ jobs:
       - name: Move target and interim data to hub directory ➡️
         run: |
           echo "Merging new target data files into target-data directory"
+          mkdir -p ${{ github.workspace }}/target-data/time-series
           cp -R ${{ github.workspace }}/time-series/* ${{ github.workspace }}/target-data/time-series/
+          mkdir -p ${{ github.workspace }}/target-data/oracle-output
           cp -R ${{ github.workspace }}/oracle-output/* ${{ github.workspace }}/target-data/oracle-output/
           echo "Contents of target-data after merge:"
           ls -lR ${{ github.workspace }}/target-data/


### PR DESCRIPTION
Our first target-data-backfill got an error when creating its corresponding PR because I had removed the `time-series` and `oracle-output` folders in target-data: https://github.com/reichlab/variant-nowcast-hub/actions/runs/13773451163/job/38517945434

This PR updates the GitHub action to create those directories (if they don't exist) before trying to copy files to them.