### PR TITLE
Make target data dates, their origin, and their purpose clearer

### DIFF
--- a/.github/actions/create-pr/action.yml
+++ b/.github/actions/create-pr/action.yml
@@ -51,5 +51,5 @@ runs:
         git push -u origin HEAD
         gh pr create \
           --base main \
-          --title "${{ inputs.pr-prefix }} \
+          --title "${{ inputs.pr-prefix }}" \
           --body "${{ inputs.pr-body }}"

--- a/.github/actions/create-pr/action.yml
+++ b/.github/actions/create-pr/action.yml
@@ -47,9 +47,9 @@ runs:
           exit 0
         fi
 
-        git commit -m "${{ inputs.commit-message }} $PR_DATETIME"
+        git commit -m "${{ inputs.commit-message }}"
         git push -u origin HEAD
         gh pr create \
           --base main \
-          --title "${{ inputs.pr-prefix }} $PR_DATETIME" \
+          --title "${{ inputs.pr-prefix }} \
           --body "${{ inputs.pr-body }}"

--- a/.github/workflows/run-post-submission-jobs.yaml
+++ b/.github/workflows/run-post-submission-jobs.yaml
@@ -25,6 +25,7 @@ jobs:
     outputs:
       NOWCAST_DATE: ${{ steps.set-dates.outputs.NOWCAST_DATE }}
       SEQUENCE_AS_OF: ${{ steps.set-dates.outputs.SEQUENCE_AS_OF }}
+      ROUND_CLOSE_DATE: ${{ steps.set-dates.outputs.ROUND_CLOSE_DATE }}
       matrix: ${{ steps.set-dates.outputs.MATRIX_DATES }}
     steps:
       - name: Checkout 🛎️
@@ -36,22 +37,33 @@ jobs:
 
       - name: Set dates 🕰️
         id: set-dates
-        # Nowcast_date = round_id of the round that just closed for submissions.
-        # Sequence_as_of = date used to get the sequences for clade assignment.
-        # Matrix_dates = dates used for matrix in create-target-data job (including
-        # the round_id of the 91-day-old round that can now be officially closed).
+        # nowcast_date = round_id of the round that just closed for submissions,
+        #    defaults to the most recent Wednesday if not explicitly set (YYYY-MM-DD)
+        # submission_close_date = an alias for nowcast_date
+        # matrix_dates = an array of 14 round_ids in YYYY-MM-DD format, starting with
+        #    nowcast_date and going back 13 weeks
+        # round_close_date = 13 weeks (91 days) before the nowcast/submission_close date,
+        #    i.e., the earliest date in matrix_dates. this round is now "closed," because
+        #    we're generating the oracle output data required to score it.
+        # sequence_as_of = date used to get the sequences for clade assignment,
+        #    calculated as the round_close_date + 90 days
         run: |
           source ${GITHUB_WORKSPACE}/.github/shared/shared-functions.sh
           nowcast_date=$(get_latest_wednesday "${{ inputs.nowcast_date }}")
-          sequence_as_of=$(date -d "$nowcast_date - 1 day" +%Y-%m-%d)
+          submission_close_date=$nowcast_date
           matrix_dates=$(generate_weekly_dates "$nowcast_date" 13)
+          round_close_date=$(echo "$matrix_dates" | jq -r '.include | min | .["nowcast-date"]')
+          sequence_as_of=$(date -d "$round_close_date + 90 days" +%Y-%m-%d)
           echo "nowcast_date=$nowcast_date" >> $GITHUB_OUTPUT
+          echo "submission_close_date=$submission_close_date" >> $GITHUB_OUTPUT
+          echo "round_close_date=$round_close_date" >> $GITHUB_OUTPUT
           echo "sequence_as_of=$sequence_as_of" >> $GITHUB_OUTPUT
           echo "matrix_dates=$matrix_dates" >> $GITHUB_OUTPUT
 
           echo -e "\nDebug values:"
           echo "Nowcast date: $nowcast_date"
           echo "Sequence as of: $sequence_as_of"
+          echo "Round close date: $round_close_date"
           echo "Matrix dates: $matrix_dates"
 
   # Create target data for the round that closed 90 days ago.
@@ -100,7 +112,11 @@ jobs:
 
   target-data-pr:
     runs-on: ubuntu-latest
-    needs: create-target-data
+    needs: [get-all-dates, create-target-data]
+    env:
+      NOWCAST_DATE: ${{ needs.get-all-dates.outputs.nowcast_date }}
+      ROUND_CLOSE_DATE: ${{ needs.get-all-dates.outputs.round_close_date }}
+      SEQUENCE_AS_OF_DATE: ${{ needs.get-all-dates.outputs.sequence_as_of }}
 
     steps:
       - name: Checkout 🛎️
@@ -134,10 +150,12 @@ jobs:
       - name: Create PR for new target and interim data
         uses: ./.github/actions/create-pr
         with:
-          pr-prefix: "add-target-data"
+          pr-prefix: "add-target-data-and-close-submissions-${{ env.NOWCAST_DATE }}"
           file-path: target-data/
-          commit-message: "Add target data and interim files."
-          pr-body: "Created via GitHub Actions: generate target and interim data."
+          commit-message: |
+            "Add target data and interim files using sequence_as_of date ${{ env.SEQUENCE_AS_OF_DATE }}."
+          pr-body: |
+            "This PR creates the oracle output file needed to score round ${{ env.ROUND_CLOSE_DATE }}."
 
   create-location-date-sequence-counts:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-post-submission-jobs.yaml
+++ b/.github/workflows/run-post-submission-jobs.yaml
@@ -152,10 +152,8 @@ jobs:
         with:
           pr-prefix: "add-target-data-and-close-submissions-${{ env.NOWCAST_DATE }}"
           file-path: target-data/
-          commit-message: |
-            "Add target data and interim files using sequence_as_of date ${{ env.SEQUENCE_AS_OF_DATE }}."
-          pr-body: |
-            "This PR creates the oracle output file needed to score round ${{ env.ROUND_CLOSE_DATE }}."
+          commit-message: "Add target data and interim files using sequence_as_of date ${{ env.SEQUENCE_AS_OF_DATE }}."
+          pr-body: "This PR creates the oracle output file needed to score round ${{ env.ROUND_CLOSE_DATE }}."
 
   create-location-date-sequence-counts:
     runs-on: ubuntu-latest
@@ -188,5 +186,5 @@ jobs:
         with:
           pr-prefix: "${{ env.NOWCAST_DATE }}-unscored-locations"
           file-path: auxiliary-data/unscored-location-dates/
-          commit-message: "Add unscored locations for round $NOWCAST_DATE"
+          commit-message: "Add unscored locations for round ${{ env.NOWCAST_DATE }}"
           pr-body: "Created via GitHub Actions: generate count of sequences collected by date/location for the past 31 days."

--- a/src/get_target_data.py
+++ b/src/get_target_data.py
@@ -244,6 +244,15 @@ def main(
     if collection_min_date is None:
         collection_min_date = tree_as_of - timedelta(days=90)
 
+    print("--------------------------------------------------")
+    logger.info("ASSIGNING CLADES FOR:")
+    logger.info(f"nowcast_date: {nowcast_date}")
+    logger.info(f"sequence_as_of: {sequence_as_of}")
+    logger.info(f"tree_as_of: {tree_as_of}")
+    logger.info(f"collection_min_date: {collection_min_date}")
+    logger.info(f"collection_max_date: {collection_max_date}")
+    print("--------------------------------------------------")
+
     assignments = assign_clades(
         nowcast_date,
         sequence_as_of,

--- a/target-data/README.md
+++ b/target-data/README.md
@@ -3,11 +3,40 @@
 The United States SARS-CoV-2 Variant Nowcast Hub generates target data in both oracle output and time series formats
 as described in the [Hubverse user guide](https://hubverse.io/en/latest/user-guide/target-data.html).
 
+## Target data process
+
+Target data files are generated weekly, after a variant-nowcast-hub closes for submissions.
+If necessary, a set of target data files can also be generated
+manually.
+
+- GitHub workflow: [`run-post-submission-jobs.yaml`](https://github.com/reichlab/variant-nowcast-hub/blob/main/.github/workflows/run-post-submission-jobs.yaml#L60)
+- Python script run by above workflow: [`get_target_data.py`](https://github.com/reichlab/variant-nowcast-hub/blob/main/src/get_target_data.py)
+
+### Dates
+
+There are four important dates used when creating a set of target data:
+
+- `nowcast_date`: The id of a modeling round (defaults to the most recent Wednesday but can be overridden).
+- `round_close_date`: The id of the modeling round that is now "closed" because 91 days have passed since
+  its nowcast_date (*i.e.*, this round's submissions can now be scored). Calculated as nowcast_date - 91 days.
+  This field is used to calculate `as_of` (see below) but is not included in the target data files.
+- `as_of`: The SARS-CoV-2 "snapshot" date used when generating target data. Calculated as the round_close_date + 90 days.
+- `tree_as_of`: The SARS-CoV-2 [reference tree](https://docs.nextstrain.org/projects/nextclade/en/stable/user/terminology.html#reference-tree-concept)
+  in use when the `nowcast_date` modeling round opened, usually nowcast_date - 2 days.
+  This field is used for clade assignments when generating target data but is not included in the target data files.
+
+### Values
+
+The target data values (`oracle_value` for oracle data and `observation` for time series) are calculated by:
+
+1. Using the `nowcast_date` to determine other required dates as described above.
+2. Downloading the set of SARS-CoV-2 genome sequences that were available on the `as_of` date.
+3. Assigning clades to those sequences using the SARS-CoV-2 reference tree in effect on the `tree_as_of` date.
+4. Summarizing the number of sequences by location, target date, and clade.
+
 ## Oracle output
 
 The hub's oracle output target data are published in parquet format and partitioned by `as_of`, a date in YYYY-MM-DD format.
-Oracle values are calculated by using SARS-CoV-2 sequence data and clade assignments as they existed on
-the `as_of` date.
 
 Oracle output files are used to evaluate model submissions and contain the following columns:
 
@@ -40,3 +69,20 @@ Time series files are used for model estimation and plotting and contain the fol
 | target_date | date | sequence collection date that corresponds to the observation |
 | clade | string | [Nextstrain clade](https://nextstrain.org/blog/2021-01-06-updated-SARS-CoV-2-clade-naming) that corresponds to the observation |
 | observation | integer | the observed total of sequences for a location, target_date, and Nextstrain clade |
+
+## Acknowledgments
+
+The United States SARS-CoV-2 Variant Nowcast Hub uses Genbank-based genome sequences
+published by Nextstrain:
+
+- [Hadfield et al., Nextstrain: real-time tracking of pathogen evolution, Bioinformatics (2018)](https://academic.oup.com/bioinformatics/article/34/23/4121/5001388?login=false)
+- [https://nextstrain.org/](https://nextstrain.org/)
+
+Additionally, the hub uses the
+[Nextclade project](https://docs.nextstrain.org/projects/nextclade/en/stable/)
+to assign clades to SARS-CoV-2 genome sequences.
+
+- Aksamentov, I., Roemer, C., Hodcroft, E. B., & Neher, R. A., (2021).
+  Nextclade: clade assignment, mutation calling and quality control for viral genomes.
+  Journal of Open Source Software, 6(67), 3773, [https://doi.org/10.21105/joss.03773](https://doi.org/10.21105/joss.03773)
+- [https://clades.nextstrain.org](https://clades.nextstrain.org)


### PR DESCRIPTION
Closes #357 

This PR includes some changes we discussed earlier today by clarifying the various dates used when creating target data.

None of these changes result in different target file names/content. 

This can be reviewed commit by commit.