### PR TITLE
Fix python config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     schedule:
       interval: "weekly"
 
-  - package-ecosystem: "python"
+  - package-ecosystem: "pip"
     # variant-nowcast-hub data pipeline scripts are in `src`
     directory: "/src/"
     schedule:


### PR DESCRIPTION
The package-ecosystem for python is "pip", not "python"

This was a mistake in the prior PR. Error message: https://github.com/reichlab/variant-nowcast-hub/runs/38919971033