### PR TITLE
Standardize Python dependencies in requirements.txt

### DIFF
--- a/.github/workflows/create-modeling-round.yaml
+++ b/.github/workflows/create-modeling-round.yaml
@@ -47,7 +47,7 @@ jobs:
         env:
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          uv run get_clades_to_model.py
+          uv run --with-requirements requirements.txt get_clades_to_model.py
           Rscript make_round_config.R
         working-directory: src
 

--- a/.github/workflows/run-post-submission-jobs.yaml
+++ b/.github/workflows/run-post-submission-jobs.yaml
@@ -96,7 +96,7 @@ jobs:
       - name: Create target data 🎯
         run: |
           echo "sequence_as_of: $SEQUENCE_AS_OF"
-          uv run get_target_data.py \
+          uv run --with-requirements requirements.txt get_target_data.py \
           --nowcast-date=${{ matrix.nowcast-date }} \
           --sequence-as-of=$SEQUENCE_AS_OF \
           --target-data-dir=${{ github.workspace }}
@@ -178,7 +178,7 @@ jobs:
 
       - name: Create file of sequence counts by location and date 🦠
         run: |
-          uv run get_location_date_counts.py --nowcast-date=$NOWCAST_DATE
+          uv run --with-requirements requirements.txt get_location_date_counts.py --nowcast-date=$NOWCAST_DATE
         working-directory: src
 
       - name: Create PR for sequence counts 🚀

--- a/src/README.md
+++ b/src/README.md
@@ -24,18 +24,19 @@ To run the script manually:
     brew install uv
     ```
 
-    (see [`uv` documentation](https://docs.astral.sh/uv/getting-started/installation/#installing-uv) for a full list of installation options)
+    (see [`uv` documentation](https://docs.astral.sh/uv/getting-started/installation/#installing-uv)
+    for a full list of installation options)
 
 2. From the root of the repo, run the following command:
 
     ```bash
-    uv run src/get_clades_to_model.py
+    uv run --with-requirements src/requirements.txt src/get_clades_to_model.py
     ```
 
 ## Adding a new modeling round to the hub
 
-`make_round_config.R` reads in the most recent clade list (see above) and uses it to generate a new modeling round, which is
-then appended to the hub's existing `hub-config/tasks.json` file.
+`make_round_config.R` reads in the most recent clade list (see above) and uses it to generate a new modeling round,
+which is then appended to the hub's existing `hub-config/tasks.json` file.
 
 To run the script manually (RStudio users):
 
@@ -74,7 +75,8 @@ the [`run-post-submission-jobs.yaml` GitHub workflow](https://github.com/reichla
 
 ### get_location_date_counts.py
 
-For each location used by this hub, `get_location_date_counts.py` generates a daily count of Sars-Cov-2 genome sequences collected.
+For each location used by this hub, `get_location_date_counts.py` generates a daily count of
+Sars-Cov-2 genome sequences collected.
 The output includes counts for each of the 31 days prior to the latest round's nowcast date (_i.e._, the round_id)
 This script writes its output to `auxiliary-data/unscored-location-dates/[round_id].csv`.
 
@@ -86,12 +88,13 @@ To run the script manually:
     brew install uv
     ```
 
-    (see [`uv` documentation](https://docs.astral.sh/uv/getting-started/installation/#installing-uv) for a full list of installation options)
+    (see [`uv` documentation](https://docs.astral.sh/uv/getting-started/installation/#installing-uv)
+    for a full list of installation options)
 
 2. From the root of the repo, run the following command:
 
     ```bash
-    uv run src/get_location_date_counts.py
+    uv run --with-requirements src/requirements.txt src/get_location_date_counts.py
     ```
 
 ### get_target_data.py
@@ -134,10 +137,11 @@ To run the script manually:
     brew install uv
     ```
 
-    (see [`uv` documentation](https://docs.astral.sh/uv/getting-started/installation/#installing-uv) for a full list of installation options)
+    (see [`uv` documentation](https://docs.astral.sh/uv/getting-started/installation/#installing-uv)
+    for a full list of installation options)
 
 2. From the root of the repo, run the following command:
 
     ```bash
-    uv run src/get_target_data.py --nowcast-date=2024-10-09
+    uv run --with-requirements src/requirements.txt src/get_target_data.py --nowcast-date=2024-10-09
     ```

--- a/src/get_clades_to_model.py
+++ b/src/get_clades_to_model.py
@@ -15,16 +15,8 @@ on the following Wednesday.
 
 To run the script manually:
 1. Install uv on your machine: https://docs.astral.sh/uv/getting-started/installation/
-2. From the root of this repo: uv run src/get_clades_to_model.py
+2. From the root of this repo: uv run --with-requirements src/requirements.txt src/get_clades_to_model.py
 """
-
-# /// script
-# requires-python = ">=3.11"
-# dependencies = [
-#   "cladetime@git+https://github.com/reichlab/cladetime",
-#   "polars>=1.17.1,<1.18.0",
-# ]
-# ///
 
 import json
 import logging

--- a/src/get_location_date_counts.py
+++ b/src/get_location_date_counts.py
@@ -9,17 +9,8 @@ The script is scheduled to run every Wednesday, after a modeling round closes.
 
 To run the script manually:
 1. Install uv on your machine: https://docs.astral.sh/uv/getting-started/installation/
-2. From the root of this repo: uv run src/get_location_date_counts.py
+2. From the root of this repo: uv run --with-requirements src/requirements.txt src/get_location_date_counts.py --nowcast-date=YYYY-MM-DD
 """
-
-# /// script
-# requires-python = ">=3.12,<3.13"
-# dependencies = [
-#   "click",
-#   "cladetime@git+https://github.com/reichlab/cladetime",
-#   "polars>=1.17.1,<1.18.0",
-# ]
-# ///
 
 import logging
 import os

--- a/src/get_target_data.py
+++ b/src/get_target_data.py
@@ -10,23 +10,13 @@ The script is scheduled to run every Wednesday evening (US Eastern)
 To run the script manually:
 1. Install uv on your machine: https://docs.astral.sh/uv/getting-started/installation/
 2. From the root of this repo:
-uv run src/get_target_data.py --nowcast-date=YYYY-MM-DD
+uv run --with-requirements src/requirements.txt src/get_target_data.py --nowcast-date=YYYY-MM-DD
 For example:
-`uv run src/get_target_data.py --nowcast-date=2024-10-09`
+`uv run --with-requirements src/requirements.txt src/get_target_data.py --nowcast-date=2024-10-09`
 
 To run the included tests manually (from the root of the repo):
 uv run --with-requirements src/requirements.txt --module pytest src/get_target_data.py
 """
-
-# /// script
-# requires-python = ">=3.12,<3.13"
-# dependencies = [
-#   "click",
-#   "cladetime",
-#   "polars>=1.17.1,<1.18.0",
-#   "pyarrow>=18.1.0,<19.0.0",
-# ]
-# ///
 
 import json
 from pathlib import Path

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -2,7 +2,11 @@
 # directory's .py files. They're replicated here so we can use run pytest
 # to invoke scripts' test_ functions (the dependencies are also part of the
 # individual scripts' metadata block for ease of use).
-click
-cladetime@git+https://github.com/reichlab/cladetime
-polars>=1.17.1,<1.27.0
-pytest
+click>=8.1.8,<8.2.0
+cladetime>=0.3.0,<0.4.0
+# old Polars streaming engine is deprecated; recommendation is to pin < 1.23
+# until the new engine is released:
+# https://github.com/pola-rs/polars/issues/20947
+polars>=1.22.0,<1.23.0
+pyarrow>=19.0.1,<19.1.0
+pytest>=8.3.5,<8.4.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,5 +4,5 @@
 # individual scripts' metadata block for ease of use).
 click
 cladetime@git+https://github.com/reichlab/cladetime
-polars>=1.17.1,<1.26.0
+polars>=1.17.1,<1.27.0
 pytest


### PR DESCRIPTION
At the beginning, `variant-nowcast-hub` had a single Python script. So we specified Python dependencies using inline metadata, and it was good.

Then we added another Python script and also used inline metadata for dependencies, and it was pretty good.

Then we added a third Python script, this one with tests. And it used inline metadata for dependencies, but we also added a requirements.txt file to support the test runner. And then it was decent but not the best.

Then we added dependabot, which doesn't work on dependencies specified via metadata.

So this PR removes all script metadata in favor of using [`--with-requirements`](https://docs.astral.sh/uv/reference/cli/#uv-run--with-requirements) with every `uv run` command.

The `uv run` command is now a bit clunky, but these scripts are designed to run via CI and not by humans.