### PR TITLE
Update README and round metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Early Monday morning (~3am ET) prior to a Wednesday on which submissions are due
 
     - links to the Nextstrain sequence information
     - the Nextclade dataset used to generate the above `clades` array
-    - the total number of sequences used to generate the round's clade list
+    - the total number of sequences from the last three weeks of data used to generate the round's clade list
 
 The JSON file will live in the `auxiliary-data/modeled-clades/` directory of the repository and will be named “YYYY-MM-DD.json” where “YYYY-MM-DD” is the date of the Wednesday on which submissions are due.
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,22 @@ We will not solicit estimates for the US as a whole, in part because evaluating 
 
 ### Predicted clades
 
-Each week the hub designates up to nine NextStrain clades with the highest reported prevalence of at least 1% across the US in any of the three complete [USA/CDC epidemiological weeks](https://ndc.services.cdc.gov/wp-content/uploads/MMWR_Week_overview.pdf) (a.k.a. MMWR weeks) preceding the Wednesday submission date. Any clades with prevalence of less than 1% are grouped into an “other” category for which predictions of combined prevalence are also collected. No more than 10 clades (including “other”) are selected in a given week. For details on the workflow that generates this list each week, see the [clade list section](#clade-list) below.
+Each week the hub designates up to nine NextStrain clades, based on the highest reported prevalence of those that
+meet the following criteria:
+
+- accounts for at least 1% of observations across the US
+- appears at least twice in any of the three complete
+  [USA/CDC epidemiological weeks](https://ndc.services.cdc.gov/wp-content/uploads/MMWR_Week_overview.pdf)
+  (a.k.a. MMWR weeks) preceding the Wednesday submission date
+
+Any clades with prevalence of less than 1% are grouped into an “other” category for which predictions of combined
+prevalence are also collected. No more than 10 clades (including “other”) are selected in a given week.
+
+**note**: Prior to the modeling round ending on 2025-04-16, a clade did not have to appear twice in the prior three MMWR
+weeks to be included. The Variant Nowcast Hub team added this criteria to ensure that clades are not selected based
+on a single observation.e.
+
+For details on the workflow that generates this list each week, see the [clade list section](#clade-list) below.
 
 #### Why use Nextstrain clades?
 
@@ -127,7 +142,11 @@ Genomic sequences tend to be reported weeks after being collected. Therefore, re
 Early Monday morning (~3am ET) prior to a Wednesday on which submissions are due, the hub generates a JSON file with two high-level properties:
 
 1. `clades`: an array of [NextClade clade names](https://clades.nextstrain.org/about) that will be accepted in submission files for the upcoming deadline.
-2. `meta`: metadata relevant to the upcoming round, including links to the Nextstrain sequence information and reference tree used to generate the above `clades` array.
+2. `meta`: metadata relevant to the upcoming round, including
+
+    - links to the Nextstrain sequence information
+    - the Nextclade dataset used to generate the above `clades` array
+    - the total number of sequences used to generate the round's clade list
 
 The JSON file will live in the `auxiliary-data/modeled-clades/` directory of the repository and will be named “YYYY-MM-DD.json” where “YYYY-MM-DD” is the date of the Wednesday on which submissions are due.
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ We will not solicit estimates for the US as a whole, in part because evaluating 
 Each week the hub designates up to nine NextStrain clades, based on the highest reported prevalence of those that
 meet the following criteria:
 
-- accounts for at least 1% of observations across the US
+- accounts for at least 1% of observations across the US in any of the three complete
+  [USA/CDC epidemiological weeks](https://ndc.services.cdc.gov/wp-content/uploads/MMWR_Week_overview.pdf)
+  (a.k.a. MMWR weeks) preceding the Wednesday submission date
 - has had at least two sequences present in the data across the last three complete
   [USA/CDC epidemiological weeks](https://ndc.services.cdc.gov/wp-content/uploads/MMWR_Week_overview.pdf)
   (a.k.a. MMWR weeks) preceding the Wednesday submission date

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Each week the hub designates up to nine NextStrain clades, based on the highest 
 meet the following criteria:
 
 - accounts for at least 1% of observations across the US
-- appears at least twice in any of the three complete
+- has had at least two sequences present in the data across the last three complete
   [USA/CDC epidemiological weeks](https://ndc.services.cdc.gov/wp-content/uploads/MMWR_Week_overview.pdf)
   (a.k.a. MMWR weeks) preceding the Wednesday submission date
 

--- a/src/get_clades_to_model.py
+++ b/src/get_clades_to_model.py
@@ -164,7 +164,7 @@ def get_metadata(ct: CladeTime, sequence_counts: pl.LazyFrame) -> dict[str, dict
         .collect()
     )
 
-    sequence_metadata["total_sequences"] = total_sequences
+    sequence_metadata["total_sequences_last_3_weeks"] = total_sequences
     sequence_metadata["sequences_by_clade"] = dict(sequences_by_clade.iter_rows())
     metadata["sequence_counts"] = sequence_metadata
 

--- a/src/get_clades_to_model.py
+++ b/src/get_clades_to_model.py
@@ -320,7 +320,7 @@ def test_metadata():
     assert ncov_metadata.get("nextclade_version_num") == "3.10.1"
 
     sequence_count_metadata = meta.get("sequence_counts", {})
-    total_sequences = sequence_count_metadata.get("total_sequences", 0)
+    total_sequences = sequence_count_metadata.get("total_sequences_last_3_weeks", 0)
     sequences_by_clade = sequence_count_metadata.get("sequences_by_clade", {})
     assert total_sequences == 15
     assert sequences_by_clade == {"23A": 1, "24E": 4, "24F": 5, "25A": 5}


### PR DESCRIPTION
Fixes #433 

This PR is a follow up to #440 and does the following:

1. Updates README.md to reflect the new inclusion criteria added by @trobacker 
2. Adds some additional information to the `auxiliary-data` JSON files created every Monday. The goal of this change is to make it easier to spot trends in sequence collection volume.

Below is a sample JSON file produced by a local run (using today's Nextstrain metadata):

```json
{
    "clades": [
        "24A",
        "24E",
        "24F",
        "24H",
        "25A",
        "recombinant",
        "other"
    ],
    "meta": {
        "created_at": "2025-04-11T18:03:46+00:00",
        "ncov": {
            "schema_version": "v1",
            "nextclade_version": "nextclade 3.12.0",
            "nextclade_dataset_name": "SARS-CoV-2",
            "nextclade_dataset_version": "2025-04-01--08-20-12Z",
            "nextclade_tsv_sha256sum": "548bb75c648a4e3fe89baba4f6a330edd3d74671b965caaf0c00bc918ddde519",
            "metadata_tsv_sha256sum": "3118288cde1167b704901a307c0ae74f6b00a69e04e666bea26423bf4e29f712",
            "nextclade_dataset_name_full": "nextstrain/sars-cov-2/wuhan-hu-1/orfs",
            "nextclade_version_num": "3.12.0",
            "metadata_version_url": "https://nextstrain-data.s3.amazonaws.com/files/ncov/open/metadata_version.json?versionId=0u0SvCtC1xMszwhsQwlW4sBc2DLGAiF5"
        },
        "sequence_counts": {
            "total_sequences": 1567,
            "sequences_by_clade": {
                "23A": 1,
                "24A": 85,
                "24B": 11,
                "24C": 10,
                "24D": 6,
                "24E": 176,
                "24F": 261,
                "24H": 161,
                "24I": 2,
                "25A": 804,
                "recombinant": 50
            }
        }
    }
}
```