### PR TITLE
Address polars streaming shenanigans

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ lf = pl.scan_parquet(
 )
 
 # use a collect operation to materialize the LazyFrame into a DataFrame
-model_output = lf.collect(streaming=True)
+model_output = lf.collect(engine="streaming")
 ```
 
 > **💡 Tip** \

--- a/src/get_location_date_counts.py
+++ b/src/get_location_date_counts.py
@@ -106,7 +106,7 @@ def get_location_date_counts(round_close_time: datetime) -> pl.DataFrame:
         .rename({"date": "target_date"})
     )
 
-    return grouped_all.collect(streaming=True)
+    return grouped_all.collect()
 
 
 def test_get_location_date_counts(monkeypatch):


### PR DESCRIPTION
This PR is the first attempt to address #455 

The Polars team is in the process creating a new streaming engine and has been issuing warnings that the old one (that the `get_location_date_counts.py` script was using) will become more stable over time.

It's not entirely clear if the recent GitHub workflow failure of this script was caused by the streaming engine, but this the hub's only Python script that uses it, so this PR removes that option to see what happens.

The PR also updates the README's Polars example code to use the new streaming syntax.

