### PR TITLE
Add information about administrative workflows to src/README

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -162,4 +162,43 @@ To run the script manually:
 
 ## Workflows
 
-Coming soon!
+Many of the scripts in `variant-nowcast-hub/src` are run via scheduled
+[GitHub workflows](https://docs.github.com/en/actions/about-github-actions/understanding-github-actions#workflows),
+usually when a new round is ready to open or when a round closes for submissions.
+
+Per GitHub standards, the workflow definitions are `.yaml` files stored in this repo's
+[`.github/workflows/`](https://github.com/reichlab/variant-nowcast-hub/tree/main/.github/workflows) directory. The
+information below maps workflows to scripts in `src/` and describes how to re-run them if needed.[^1]
+
+### create-modeling-round.yaml
+
+This workflow generates the data required to open a new modeling round and opens a corresponding PR.
+
+- Scheduled to run on Mondays at 3 AM UTC
+- Runs the following scripts:
+
+    - `get_clades_to_model.py`
+    - `make_round_config.R`
+- Re-running:
+
+    - The round_id used by this workflow is calculated as the Wednesday following the run date.
+    - Therefore, it can be safely re-run on the Monday or Tuesday of the current round.
+
+### run-post-submission-jobs.yaml
+
+This workflow runs after submissions close for a round. It generates updated target-data and unscored-location-dates
+files for the specified round and opens a corresponding PR.
+
+- Scheduled to run on Thursdays at 12:20 or 1:20 AM UTC (depending on the month; best we could do to accommodate DST)
+- Runs the following scripts:
+
+    - `get_location_date_counts.py`
+    - `get_target_data.py`
+- Re-running:
+
+    - This workflow can be re-run manually for any past round_id.
+    - If a round_id is not specified, it will use the latest round as determined by the date
+      of the most recent Wednesday.
+
+[^1]: Not all workflows are listed here. Many of them are generic Hubverse actions and are documented in
+[`hubverse-actions`](https://github.com/hubverse-org/hubverse-actions).

--- a/src/README.md
+++ b/src/README.md
@@ -1,17 +1,31 @@
-# For Hub Admins: Variant Nowcast Hub Scripts
+# For Hub Admins: Variant Nowcast Hub Scripts and Workflows
 
 > [!IMPORTANT]
 > **The `src/` directory contains scripts used by hub administrators** and automated jobs.
 > Hub participants and modelers: turn back now. There is nothing for you here but misery.
 
-Details of these scripts can be found below. All of these scripts assume that your working directory is the `src/` directory. To ensure stability, the R scripts manage their dependencies with [the renv R package](https://rstudio.github.io/renv/). The `variant-hub-admin.Rproj` file allows you to open the `src/` folder as an independent R project from the root of this hub.
+## Table of contents
+
+  - [Scripts](#scripts)
+  - [GitHub workflows](#workflows)
+
+## Scripts
+
+Details of the scripts in this folder can be found below. All of them assume that your working directory is the `src/`
+directory. To ensure stability:
+
+- R scripts manage their dependencies with [the renv R package](https://rstudio.github.io/renv/).
+  The `variant-hub-admin.Rproj` file allows you to open the `src/` folder as an independent R project from
+  the root of this hub.
+- Python scripts are run via `uv` commands that create transient virtual environments based on the dependencies in
+  [`requirements.txt`](requirements.txt).
 
 The scripts are designed to be run by scheduled GitHub workflows on a Linux-based runner
 (_i.e._, they have not been tested in a Windows environment).
 
 The sections below contain information about the scripts and how to run them manually.
 
-## Generating list of clades to model
+### Generating list of clades to model
 
 `get_clades_to_model.py` generates a list of clades to model for the hub's upcoming round (the first Wednesday following
 the run date). The script writes the clade list and accompanying metadata to `auxiliary-data/modeled-clades/[round_id].json`.
@@ -33,7 +47,7 @@ To run the script manually:
     uv run --with-requirements src/requirements.txt src/get_clades_to_model.py
     ```
 
-## Adding a new modeling round to the hub
+### Adding a new modeling round to the hub
 
 `make_round_config.R` reads in the most recent clade list (see above) and uses it to generate a new modeling round,
 which is then appended to the hub's existing `hub-config/tasks.json` file.
@@ -68,12 +82,12 @@ To run the script manually (without RStudio):
      source("make_round_config.R")
     ```
 
-## Post round-submission scripts
+### Post round-submission scripts
 
 After a modeling round closes for submissions (Wednesdays at 8 PM US Eastern),
 the [`run-post-submission-jobs.yaml` GitHub workflow](https://github.com/reichlab/variant-nowcast-hub/blob/main/.github/workflows/run-post-submission-jobs.yaml) runs two of the scripts in this directory.
 
-### get_location_date_counts.py
+#### get_location_date_counts.py
 
 For each location used by this hub, `get_location_date_counts.py` generates a daily count of
 Sars-Cov-2 genome sequences collected.
@@ -97,7 +111,7 @@ To run the script manually:
     uv run --with-requirements src/requirements.txt src/get_location_date_counts.py
     ```
 
-### get_target_data.py
+#### get_target_data.py
 
 `get_target_data.py` generates a sets of oracle output and timeseries target
 data. This script is actually a small command line interface (CLI), with
@@ -145,3 +159,7 @@ To run the script manually:
     ```bash
     uv run --with-requirements src/requirements.txt src/get_target_data.py --nowcast-date=2024-10-09
     ```
+
+## Workflows
+
+Coming soon!


### PR DESCRIPTION
Closes #460 

Today's failure of the run-post-submissions-jobs workflow was a reminder that we don't have good documentation on whether or not it's safe to run the variant nowcast hub's automated jobs.

This PR adds some brief information about the behavior of administrative workflows and how they handle round_ids when they are re-run.