### PR TITLE
Updating cache-hubval-deps.yaml to fix pak bug

### DIFF
--- a/.github/workflows/cache-hubval-deps.yaml
+++ b/.github/workflows/cache-hubval-deps.yaml
@@ -32,6 +32,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@bd49c52ffe281809afa6f0fecbf37483c5dd0b93  #v2.11.3
         with:
+          pak-version: "devel"
           packages: |
             any::hubValidations
             any::sessioninfo


### PR DESCRIPTION
Applying the fix suggested in :https://github.com/r-lib/pkgbuild/issues/208#issuecomment-2863012401 to fix a bug with pak that is causing the cache-hubval-deps.yaml workflow runs to fail. This is the same fix as in https://github.com/reichlab/variant-nowcast-hub/pull/503, just for a different workflow.