### PR TITLE
Register Bedford Lab hierarchical MLR model

### DIFF
--- a/model-metadata/blab-gisaid_hier_mlr.yml
+++ b/model-metadata/blab-gisaid_hier_mlr.yml
@@ -1,6 +1,6 @@
 team_name: "Bedford Lab"
 team_abbr: "blab"
-model_name: "GISAID-based Hierarchical Multinomial Logistic Regression"
+model_name: "GISAID-based Hierarchical MLR"
 model_abbr: "gisaid_hier_mlr"
 model_version: "1.0"
 model_contributors: [
@@ -32,7 +32,7 @@ model_contributors: [
 ]
 license: "CC-BY-4.0"
 team_funding: "This work has been supported by NIH NIGMS award R35 GM119774, Howard Hughes Medical Institute COVID-19 Collaboration Initiative award, National Science Foundation Graduate Research Fellowship Program under grant No. DGE1762114, and the Centers of Excellence for Influenza Research and Response (NIH NIAID contract 75N93021C00015). The content is solely the responsibility of the authors and does not necessarily represent the official views of NIGMS, the National Institutes of Health, or Howard Hughes Medical Institute."
-methods: "A Bayesian hierarchical multinomial logistic regression model for nowcasting COVID variants using variant counts based on GISAID sequences. Regression coefficents are modeled hierarchically across locations as described in Abousamra, Figgins and Bedford (PLOS Computational Biology, 2024)."
+methods: "A Bayesian hierarchical multinomial logistic regression (MLR) model for nowcasting COVID variants using variant counts based on GISAID sequences. Regression coefficents are modeled hierarchically across locations as described in Abousamra, Figgins and Bedford (PLOS Computational Biology, 2024)."
 methods_url: "https://github.com/nextstrain/forecasts-ncov/blob/main/README.md#usa-specific-models"
 data_sources: "GISAID"
 ensemble_of_models: false

--- a/model-metadata/blab-gisaid_hier_mlr.yml
+++ b/model-metadata/blab-gisaid_hier_mlr.yml
@@ -1,0 +1,40 @@
+team_name: "Bedford Lab"
+team_abbr: "blab"
+model_name: "GISAID-based Hierarchical Multinomial Logistic Regression"
+model_abbr: "gisaid_hier_mlr"
+model_version: "1.0"
+model_contributors: [
+  {
+    "name": "Marlin Figgins",
+    "affiliation": "Vaccine and Infectious Disease Division, Fred Hutchinson Cancer Center, Seattle, WA",
+    "email": "mfiggins@fredhutch.org"
+  },
+  {
+    "name": "Jover Lee",
+    "affiliation": "Vaccine and Infectious Disease Division, Fred Hutchinson Cancer Center, Seattle, WA",
+    "email": "joverlee@fredhutch.org"
+  },
+  {
+    "name": "John Huddleston",
+    "affiliation": "Vaccine and Infectious Disease Division, Fred Hutchinson Cancer Center, Seattle, WA",
+    "email": "jhuddles@fredhutch.org"
+  },
+  {
+    "name": "James Hadfield",
+    "affiliation": "Vaccine and Infectious Disease Division, Fred Hutchinson Cancer Center, Seattle, WA",
+    "email": "jhadfiel@fredhutch.org"
+  },
+  {
+    "name": "Trevor Bedford",
+    "affiliation": "Vaccine and Infectious Disease Division, Fred Hutchinson Cancer Center, Seattle, WA and Howard Hughes Medical Institute, Seattle, WA",
+    "email": "tb@bedford.io"
+  }
+]
+license: "CC-BY-4.0"
+team_funding: "This work has been supported by NIH NIGMS award R35 GM119774, Howard Hughes Medical Institute COVID-19 Collaboration Initiative award, National Science Foundation Graduate Research Fellowship Program under grant No. DGE1762114, and the Centers of Excellence for Influenza Research and Response (NIH NIAID contract 75N93021C00015). The content is solely the responsibility of the authors and does not necessarily represent the official views of NIGMS, the National Institutes of Health, or Howard Hughes Medical Institute."
+methods: "A Bayesian hierarchical multinomial logistic regression model for nowcasting COVID variants using variant counts based on GISAID sequences. Regression coefficents are modeled hierarchically across locations as described in Abousamra, Figgins and Bedford (PLOS Computational Biology, 2024)."
+methods_url: "https://github.com/nextstrain/forecasts-ncov/blob/main/README.md#usa-specific-models"
+data_sources: "GISAID"
+ensemble_of_models: false
+ensemble_of_hub_models: false
+repo_url: "https://github.com/nextstrain/forecasts-ncov"


### PR DESCRIPTION
Adds metadata for the Bedford Lab's hierarchical MLR model (https://nextstrain.org/sars-cov-2/forecasts).