### PR TITLE
Revert "Bump aws-actions/configure-aws-credentials from 4.2.1 to 4.3.0"

### DIFF
--- a/.github/workflows/hubverse-aws-upload.yaml
+++ b/.github/workflows/hubverse-aws-upload.yaml
@@ -38,7 +38,7 @@ jobs:
     - name: Configure AWS credentials
       # request credentials to assume the hub's AWS role via OpenID Connect
       if: env.CLOUD_ENABLED == 'true'
-      uses: aws-actions/configure-aws-credentials@59b441846ad109fa4a1549b73ef4e149c4bfb53b  #v4.3.0
+      uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df  #v4.2.1
       with:
         role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT }}:role/${{ env.CLOUD_STORAGE_LOCATION }}
         aws-region: us-east-1


### PR DESCRIPTION
Reverting the PR to upgrade the aws-credentials from 4.2.1 to 4.3.0 because it is causing the "Upload hub data to a hubverse-hosted AWS S3 bucket" run to fail. I'm not sure how to fix this problem, so as a temporary solution, I am reverting it. 