### PR TITLE
Add setting of PRNG for scoring to be reproducible across all setting…

### DIFF
--- a/src/model_scoring_functions.R
+++ b/src/model_scoring_functions.R
@@ -22,6 +22,15 @@ get_energy_scores <- function(
   require("arrow")
   require("scoringRules")
 
+  # Extract the date from model_output_file for set.seed using regex
+  date_str <- sub(".*?(\\d{4}-\\d{2}-\\d{2}).*", "\\1", model_output_file)
+
+  # Remove dashes to get a numeric sequence string
+  date_str <- gsub("-", "", date_str)
+
+  # Set PRNG seed for reproducibility
+  set.seed(as.integer(date_str))
+
   data <- process_target_data(hub_path = hub_path,
                               model_output_file = model_output_file,
                               ref_date = as.Date(ref_date),


### PR DESCRIPTION
Set the pseudo random number generator for scoring reproducibility:
* Uses the date of the nowcast (from model submission file) to set the seed by converting the date -> sequence -> integer.

I checked this for a couple dates and different teams, one can verify the reproducibility by scoring twice, e.g.:
`df_score_1 <- get_energy_scores(hub_path = here::here(), model_output_file = "UGA-multicast/2025-04-02-UGA-multicast.parquet", ref_date = "2025-04-02")`
`df_score_2 <- get_energy_scores(hub_path = here::here(), model_output_file = "UGA-multicast/2025-04-02-UGA-multicast.parquet", ref_date = "2025-04-02")`

and checking that the energy/brier scores are consistent. 