### PR TITLE
Updating the baseline model metadata

### DIFF
--- a/model-metadata/Hub-baseline.yml
+++ b/model-metadata/Hub-baseline.yml
@@ -22,7 +22,7 @@ model_contributors: [
 ]
 license: "CC-BY-4.0"
 team_funding: "This work has been supported by the National Institutes of General Medical Sciences (R35GM119582) and the US Centers for Disease Control and Prevention’s Center for Forecasting and Outbreak Analytics (NU38FT000008). The content is solely the responsibility of the authors and does not necessarily represent the official views of NIGMS, the National Institutes of Health, or CDC."
-methods: "A Bayesian multinomial logistic regression model that makes predictions the national level. This model uses a linear in logit space model for the growth of the variants and makes the same predictions for each state. The model uses 50 days of data before the target date to make predictions and obtains MCMC draws for the posterior distrubtion using rstan. The model started submitting for the week of 2025/04/02; all submissions before that are retrospective."
+methods: "A Bayesian multinomial logistic regression model that makes predictions the national level. This model uses a linear in logit space model for the growth of the variants and makes the same predictions for each state. The model uses 70 days of data as of the 2026-04-29 round (50 days of data before that round) before the target date to make predictions and obtains MCMC draws for the posterior distrubtion using rstan. The model started submitting for the week of 2025/04/02; all submissions before that are retrospective."
 methods_url: "https://github.com/reichlab/variant-nowcast-hub/discussions/313"
 data_sources: "NextStrain"
 ensemble_of_models: false


### PR DESCRIPTION
Updating the baseline model metadata to account for a change made to the number of days of training data used to fit the model from 50 to 70.

This change was based on internal analysis, which showed that the model was more stable with 70 days of training data compared to the 50 days of data that were being used. In practice, the model was unstable for the 2026-04-29 modeling round, which led us to make this change.   