### PR TITLE
Fix GITHUB_PAT format error caused by new ghs_ token format

### DIFF
--- a/.github/workflows/cache-hubval-deps.yaml
+++ b/.github/workflows/cache-hubval-deps.yaml
@@ -14,8 +14,6 @@ jobs:
   build-deps-cache-on-main:
     if: ${{ github.repository_owner == 'reichlab' }}
     runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v5
@@ -31,6 +29,8 @@ jobs:
           sudo apt-get update
 
       - uses: r-lib/actions/setup-r-dependencies@bd49c52ffe281809afa6f0fecbf37483c5dd0b93  #v2.11.3
+        env:
+          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
         with:
           pak-version: "devel"
           packages: |

--- a/.github/workflows/create-ensemble.yaml
+++ b/.github/workflows/create-ensemble.yaml
@@ -38,8 +38,6 @@ jobs:
           working-directory: src
 
       - name: Create ensemble model 🦠
-        env:
-          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
         run: |
           Rscript ensemble_model.R
         working-directory: src

--- a/.github/workflows/create-modeling-round.yaml
+++ b/.github/workflows/create-modeling-round.yaml
@@ -44,8 +44,6 @@ jobs:
           working-directory: src
 
       - name: Create clade list and update tasks.json 🦠
-        env:
-          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
         run: |
           uv run --with-requirements requirements.txt get_clades_to_model.py
           Rscript make_round_config.R

--- a/.github/workflows/update-scores-weekly.yaml
+++ b/.github/workflows/update-scores-weekly.yaml
@@ -53,15 +53,11 @@ jobs:
           working-directory: src
 
       - name: Update weekly scores 📊
-        env:
-          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
         run: |
           Rscript update_scores_weekly.R
         working-directory: src
 
       - name: Update weekly coverage 📈
-        env:
-          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
         run: |
           Rscript update_coverage_weekly.R
         working-directory: src

--- a/.github/workflows/validate-config.yaml
+++ b/.github/workflows/validate-config.yaml
@@ -16,7 +16,6 @@ jobs:
   validate-hub-config:
     runs-on: ubuntu-latest
     env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       PR_NUMBER: ${{ github.event.number }}
       HUB_PATH: ${{ github.workspace }}
 
@@ -34,6 +33,8 @@ jobs:
           sudo apt-get update
 
       - uses: r-lib/actions/setup-r-dependencies@bd49c52ffe281809afa6f0fecbf37483c5dd0b93  #v2.11.3
+        env:
+          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
         with:
           cache: 'always'
           packages: |

--- a/.github/workflows/validate-submission.yaml
+++ b/.github/workflows/validate-submission.yaml
@@ -15,8 +15,6 @@ on:
 jobs:
   validate-submission:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v5
@@ -32,6 +30,8 @@ jobs:
           sudo apt-get update
 
       - uses: r-lib/actions/setup-r-dependencies@bd49c52ffe281809afa6f0fecbf37483c5dd0b93  #v2.11.3
+        env:
+          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
         with:
           pak-version: "devel"
           packages: |


### PR DESCRIPTION
GitHub changed the GITHUB_TOKEN format on 2026-04-27 from a short ~40-char ghs_ string to a longer ~520-char JWT. The old format accidentally passed gh R package PAT validation (ghs_ matched the gh[pousr]_ character class and fit within length bounds). The new format fails on both length and character constraints.

Group A (validate-submission, validate-config, cache-hubval-deps): Move GITHUB_PAT from job-level to setup-r-dependencies step only, so pak retains authenticated access while the R script execution steps use gh's GITHUB_TOKEN fallback.

Group B (create-ensemble, create-modeling-round, update-scores-weekly): Remove GITHUB_PAT from R script execution steps only. The setup-renv step retains GITHUB_PAT since renv does not call validate_gh_pat() and needs auth for package downloads.

Tested locally against PR #1193 (UGA-multicast 2026-05-27): broken state reproduces the format warning; fix passes all 23 validation checks cleanly.
Co-authored by Claude